### PR TITLE
Add a validation function to check if project is compiled

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -73,13 +73,13 @@ function! PSCIDEstart(silent)
 endfunction
 
 if v:version > 704 || (v:version == 704 && has('patch279'))
-    function! s:globpath(dir, pattern) abort
-        return globpath(a:dir, a:pattern, 1, 1)
-    endfunction
+  function! s:globpath(dir, pattern) abort
+    return globpath(a:dir, a:pattern, 1, 1)
+  endfunction
 else
-    function! s:globpath(dir, pattern) abort
-        return split(globpath(a:dir, a:pattern, 1), '\n')
-    endfunction
+  function! s:globpath(dir, pattern) abort
+    return split(globpath(a:dir, a:pattern, 1), '\n')
+  endfunction
 endif
 
 
@@ -130,14 +130,14 @@ function! s:projectProblems()
   let problems = []
 
   if bowerdir == ""
-      let problem = "Your project is missing a bower.json file"
-      call add(problems, problem)
+    let problem = "Your project is missing a bower.json file"
+    call add(problems, problem)
   else
-      let outputcontent = s:globpath(bowerdir, "output/*")
-      if len(outputcontent) == 0
-          let problem = "Your project's /output directory is empty.  You should run `pulp build` to compile your project."
-          call add(problems, problem)
-      endif
+    let outputcontent = s:globpath(bowerdir, "output/*")
+    if len(outputcontent) == 0
+      let problem = "Your project's /output directory is empty.  You should run `pulp build` to compile your project."
+      call add(problems, problem)
+    endif
   endif
 
   return problems
@@ -649,7 +649,7 @@ function! s:callPscIde(input, errorm, isRetry)
   call s:log("callPscIde: start: Executing command: " . string(a:input), 3)
 
   if s:projectvalid == 0
-      call PSCIDEprojectValidate()
+    call PSCIDEprojectValidate()
   endif
 
   if s:pscidestarted == 0


### PR DESCRIPTION
Thanks for making this plugin!

When I first ran the plugin, I wasn't sure why the psc-ide-server kept successfully returning an empty response, even though everything appeared to be setup and running correctly.  It looks like psc-ide-server doesn't have a command to "build" the project, only to "rebuild" individual files - so the user has to know/remember to run `pulp build` before they start using the plugin.  

I thought it might be helpful to read the files in the /output directory, and if that folder is empty to add some logs that tell the user that they should compile their project with `pulp build`

I also am using an older version of vim that comes with ubuntu 14.01 (7.4.52), which has different parameters for the globpath function - so I added a s:globpath wrapper that will support both versions.
