### PR TITLE
Make check more platform independent

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -754,7 +754,7 @@ function! s:callPscIde(input, errorm, isRetry)
   let resp = s:mysystem("psc-ide-client -p " . g:psc_ide_server_port, enc)
   call s:log("callPscIde: Raw response: " . resp, 3)
 
-  if resp =~ "connection refused"  "TODO: This check is probably not crossplatform
+  if resp =~? "connection refused"  "TODO: This check is probably not crossplatform
     let s:pscidestarted = 0
     let s:pscideexternal = 0
 


### PR DESCRIPTION
On my platform (MacVim, OS/X El Capitan) the message is `"Connection refused"` and `=~` inherits Vim global case sensitivity setting, which is `noignorecase` for me. Thus, check fails.
