### PR TITLE
pass globs as strings when starting the server

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -73,7 +73,7 @@ function! PSCIDEstart(silent)
   if has('win16') || has('win32') || has('win64')
     let command = "start /b psc-ide-server " . dir . "/src/**/*.purs " . dir . "/bower_components/**/*.purs -p " . g:psc_ide_server_port . " -d " . dir
   else
-    let command = "psc-ide-server " . dir . "/src/**/*.purs " . dir . "/bower_components/**/*.purs -p " . g:psc_ide_server_port . " -d " . dir . " > /dev/null &"
+    let command = "psc-ide-server \"src/**/*.purs\" \"bower_components/**/*.purs\" -p " . g:psc_ide_server_port . " -d " . dir . " > /dev/null &"
   endif
   let resp = system(command)
 


### PR DESCRIPTION
Vim uses the shell to execute `system()`, which will expand the globs
for you before executing the command. This means that you will end up
calling `psc-ide-server` passing every purescript file in your source
and bower directories as command line arguments. Aside from the fact
that there is a limit to the argument length for a command, this also
means that if you add one or more files to the project and issue a
`load` command, those source files will not be loaded until the server
is stopped and restarted, meaning you can't jump to definitions.

Fortunately, `psc-ide-server` was built to take source globs, so all we
need to do is quote the globs so that the shell does not expand them. In
addition, the ide server resolves those globs relative to the working
directory, which is specified with `-d`. Since we provide this, we don't
have to concatenate the directory to the globs ourselves.

I did not change the windows command, as I did not have a way of testing
to verify that it works there too.

Here's an example of the difference.

Before:

```
$ ps -eo cmd | grep psc-ide-server
psc-ide-server /tmp/doug/tmp.uZKzvSnuaf/src/Test.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-console/src/Control/Monad/Eff/Console.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-eff/src/Control/Monad/Eff/Class.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-eff/src/Control/Monad/Eff.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-eff/src/Control/Monad/Eff/Unsafe.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Control/Applicative.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Control/Apply.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Control/Bind.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Control/Category.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Control/Monad.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Control/Semigroupoid.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/BooleanAlgebra.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Boolean.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Bounded.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/CommutativeRing.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Eq.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/EuclideanRing.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Field.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Function.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Functor.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/HeytingAlgebra.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/NaturalTransformation.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Ordering.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Ord.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Ord/Unsafe.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Ring.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Semigroup.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Semiring.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Show.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Unit.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Data/Void.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-prelude/src/Prelude.purs /tmp/doug/tmp.uZKzvSnuaf/bower_components/purescript-psci-support/src/PSCI/Support.purs -p 4242 -d /tmp/doug/tmp.uZKzvSnuaf
```

After:

```
$ ps -eo cmd | grep psc-ide-server
psc-ide-server src/**/*.purs bower_components/**/*.purs -p 4242 -d /tmp/doug/tmp.uZKzvSnuaf
```
