### PR TITLE
use async jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ This plugin provides two kinds of syntax checking with syntastic. Controlling wh
 * :PSCIDEcaseSplit : Splits variables in a function declaration into its different constructors. Will probably get improved soon so you don't have to input the type yourself
 
 ![:PSCIDEcaseSplit gif](http://frigoeu.github.io/gifs/casesplit.gif)
-* :PSCIDEremoveImportQualifications : Remove all qualifications from your imports
 
-![:PSCIDEremoveimport gif](http://frigoeu.github.io/gifs/removeimport.gif)
 * :PSCIDEaddImportQualifications : Applies all import qualification suggestions in one go. Same as :PSCIDEapplySuggestion, but applies it to every line starting with "import"
 
 ![:PSCIDEaddimport gif](http://frigoeu.github.io/gifs/addimport.gif)

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ This plugin provides two kinds of syntax checking with syntastic. Controlling wh
 No custom mappings are provided, but it's easy to map the above commands to any key mapping you want. My personal setup:
 
 ```
-au FileType purescript nmap <leader>t :PSCIDEtype<CR>
-au FileType purescript nmap <leader>s :PSCIDEapplySuggestion<CR>
-au FileType purescript nmap <leader>a :PSCIDEaddTypeAnnotation<CR>
-au FileType purescript nmap <leader>i :PSCIDEimportIdentifier<CR>
-au FileType purescript nmap <leader>r :PSCIDEload<CR>
-au FileType purescript nmap <leader>p :PSCIDEpursuit<CR>
-au FileType purescript nmap <leader>c :PSCIDEcaseSplit<CR>
-au FileType purescript nmap <leader>qd :PSCIDEremoveImportQualifications<CR>
-au FileType purescript nmap <leader>qa :PSCIDEaddImportQualifications<CR>
+au FileType purescript nmap <buffer> <leader>t :<C-U>PSCIDEtype<CR>
+au FileType purescript nmap <buffer> <leader>s :<C-U>PSCIDEapplySuggestion<CR>
+au FileType purescript nmap <buffer> <leader>a :<C-U>PSCIDEaddTypeAnnotation<CR>
+au FileType purescript nmap <buffer> <leader>i :<C-U>PSCIDEimportIdentifier<CR>
+au FileType purescript nmap <buffer> <leader>r :<C-U>PSCIDEload<CR>
+au FileType purescript nmap <buffer> <leader>p :<C-U>PSCIDEpursuit<CR>
+au FileType purescript nmap <buffer> <leader>c :<C-U>PSCIDEcaseSplit<CR>
+au FileType purescript nmap <buffer> <leader>qd :<C-U>PSCIDEremoveImportQualifications<CR>
+au FileType purescript nmap <buffer> <leader>qa :<C-U>PSCIDEaddImportQualifications<CR>
 ```
 
 

--- a/autoload/async/job.vim
+++ b/autoload/async/job.vim
@@ -1,0 +1,182 @@
+" Author: Prabir Shrestha <mail at prabir dot me>
+" License: The MIT License
+" Website: https://github.com/prabirshrestha/async.vim
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:jobidseq = 0
+let s:jobs = {} " { job, opts, type: 'vimjob|nvimjob'}
+let s:job_type_nvimjob = 'nvimjob'
+let s:job_type_vimjob = 'vimjob'
+let s:job_error_unsupported_job_type = -2 " unsupported job type
+
+function! s:job_supported_types() abort
+    let l:supported_types = []
+    if has('nvim')
+        let l:supported_types += [s:job_type_nvimjob]
+    endif
+    if !has('nvim') && has('job') && has('channel') && has('lambda')
+        let l:supported_types += [s:job_type_vimjob]
+    endif
+    return l:supported_types
+endfunction
+
+function! s:job_supports_type(type) abort
+    return index(s:job_supported_types(), a:type) >= 0
+endfunction
+
+function! s:out_cb(job, data, jobid, opts) abort
+    if has_key(a:opts, 'on_stdout')
+        call a:opts.on_stdout(a:jobid, split(a:data, "\n", 1), 'stdout')
+    endif
+endfunction
+
+function! s:err_cb(job, data, jobid, opts) abort
+    if has_key(a:opts, 'on_stderr')
+        call a:opts.on_stderr(a:jobid, split(a:data, "\n", 1), 'stderr')
+    endif
+endfunction
+
+function! s:exit_cb(job, status, jobid, opts) abort
+    if has_key(a:opts, 'on_exit')
+        call a:opts.on_exit(a:jobid, a:status, 'exit')
+    endif
+    if has_key(s:jobs, a:jobid)
+        call remove(s:jobs, a:jobid)
+    endif
+endfunction
+
+function! s:on_stdout(jobid, data, event) abort
+    if has_key(s:jobs, a:jobid)
+        let l:jobinfo = s:jobs[a:jobid]
+        if has_key(l:jobinfo.opts, 'on_stdout')
+            call l:jobinfo.opts.on_stdout(a:jobid, a:data, a:event)
+        else
+            echom "No on_stdout"
+        endif
+    endif
+endfunction
+
+function! s:on_stderr(jobid, data, event) abort
+    if has_key(s:jobs, a:jobid)
+        let l:jobinfo = s:jobs[a:jobid]
+        if has_key(l:jobinfo.opts, 'on_stderr')
+            call l:jobinfo.opts.on_stderr(a:jobid, a:data, a:event)
+        endif
+    endif
+endfunction
+
+function! s:on_exit(jobid, status, event) abort
+    if has_key(s:jobs, a:jobid)
+        let l:jobinfo = s:jobs[a:jobid]
+        if has_key(l:jobinfo.opts, 'on_exit')
+            call l:jobinfo.opts.on_exit(a:jobid, a:status, a:event)
+        endif
+    endif
+endfunction
+
+function! s:job_start(cmd, opts) abort
+    let l:jobtypes = s:job_supported_types()
+    let l:jobtype = ''
+
+    if has_key(a:opts, 'type')
+        if type(a:opts.type) == type('')
+            if !s:job_supports_type(a:opts.type)
+                return s:job_error_unsupported_job_type
+            endif
+            let l:jobtype = a:opts.type
+        else
+            let l:jobtypes = a:opts.type
+        endif
+    endif
+
+    if empty(l:jobtype)
+        " find the best jobtype
+        for l:jobtype2 in l:jobtypes
+            if s:job_supports_type(l:jobtype2)
+                let l:jobtype = l:jobtype2
+            endif
+        endfor
+    endif
+
+    if l:jobtype == ''
+        return s:job_error_unsupported_job_type
+    endif
+
+    if l:jobtype == s:job_type_nvimjob
+        let l:job = jobstart(a:cmd, {
+            \ 'on_stdout': function('s:on_stdout'),
+            \ 'on_stderr': function('s:on_stderr'),
+            \ 'on_exit': function('s:on_exit'),
+        \})
+        if l:job <= 0
+            return l:job
+        endif
+        let l:jobid = l:job " nvimjobid and internal jobid is same
+        let s:jobs[l:jobid] = {
+            \ 'type': s:job_type_nvimjob,
+            \ 'opts': a:opts,
+        \ }
+        let s:jobs[l:jobid].job = l:job
+    elseif l:jobtype == s:job_type_vimjob
+        let s:jobidseq = s:jobidseq + 1
+        let l:jobid = s:jobidseq
+        let l:job  = job_start(a:cmd, {
+            \ 'out_cb': {job,data->s:out_cb(job, data, l:jobid, a:opts)},
+            \ 'err_cb': {job,data->s:err_cb(job, data, l:jobid, a:opts)},
+            \ 'exit_cb': {job,data->s:exit_cb(job, data, l:jobid, a:opts)},
+            \ 'mode': 'raw',
+        \})
+        if job_status(l:job) != 'run'
+            return -1
+        endif
+        let s:jobs[l:jobid] = {
+            \ 'type': s:job_type_vimjob,
+            \ 'opts': a:opts,
+            \ 'job': l:job,
+            \ 'channel': job_getchannel(l:job)
+        \ }
+    else
+        return s:job_error_unsupported_job_type
+    endif
+
+    return l:jobid
+endfunction
+
+function! s:job_stop(jobid) abort
+    if has_key(s:jobs, a:jobid)
+        let l:jobinfo = s:jobs[a:jobid]
+        if l:jobinfo.type == s:job_type_nvimjob
+            call jobstop(a:jobid)
+        elseif l:jobinfo.type == s:job_type_vimjob
+            call job_stop(s:jobs[a:jobid].job)
+        endif
+        if has_key(s:jobs, a:jobid)
+            call remove(s:jobs, a:jobid)
+        endif
+    endif
+endfunction
+
+function! s:job_send(jobid, data) abort
+    let l:jobinfo = s:jobs[a:jobid]
+    if l:jobinfo.type == s:job_type_nvimjob
+        return jobsend(a:jobid, a:data)
+    elseif l:jobinfo.type == s:job_type_vimjob
+        return ch_sendraw(l:jobinfo.channel, a:data)
+    endif
+endfunction
+
+" public apis {{{
+function! async#job#start(cmd, opts) abort
+    return s:job_start(a:cmd, a:opts)
+endfunction
+
+function! async#job#stop(jobid) abort
+    call s:job_stop(a:jobid)
+endfunction
+
+function! async#job#send(jobid, data) abort
+    return s:job_send(a:jobid, a:data)
+endfunction
+" }}}

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -396,12 +396,11 @@ function! PSCIDErebuild(async, ...)
 	  \ { msg -> CallBack(s:PSCIDErebuildCallback(filename, msg)) }
 	  \ )
   else
-    return CallBack(
-	    s:PSCIDErebuildCallback(
+    let resp = s:PSCIDErebuildCallback(
 	      \ filename,
 	      \ s:callPscIdeSync(input, 0, 0),
 	      \ )
-	  \ )
+    return CallBack(resp)
   endif
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1036,15 +1036,6 @@ endfunction
   "endif
 "endfunction
 
-" Automatically close the server when leaving vim
-augroup PscideShutDown
-  au!
-  autocmd VimLeavePre * call s:Shutdown()
-augroup END
-function! s:Shutdown()
-  silent PSCIDEend
-endfunction
-
 " " Automatic import after completion
 " function! s:completeDone(item)
 "   if g:psc_ide_auto_imports == 0

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1048,7 +1048,9 @@ endfunction
 function! s:PscIdeCallback(input, errorm, isRetry, cb, resp)
   call s:log("s:PscIdeCallback: Raw response: " . a:resp, 3)
 
-  if a:resp =~? "connection refused"  "TODO: This check is probably not crossplatform
+  try
+    let decoded = json_decode(a:resp)
+  catch /.*/
     let s:pscidestarted = 0
     let s:pscideexternal = 0
 
@@ -1061,9 +1063,8 @@ function! s:PscIdeCallback(input, errorm, isRetry, cb, resp)
       " retrying is then the next best thing
       return s:callPscIde(a:input, a:errorm, 1, a:cb) " Keeping track of retries so we only retry once
     endif
-  endif
+  endtry
 
-  let decoded = json_decode(a:resp)
   call s:log("s:PscIdeCallback: Decoded response: " . string(decoded), 3)
 
   if (type(decoded) != type({}) || decoded['resultType'] !=# 'success') 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -82,7 +82,7 @@ function! PSCIDEstart(silent)
 	\ command,
 	\ { "stoponexit": "term"
 	\ , "err_mode": "raw"
-	\ , "err_cb": { ch, msg -> s:log("psc-ide-server error: " . string(msg)) }
+	\ , "err_cb": { ch, msg -> s:log("psc-ide-server error: " . string(msg), 0) }
 	\ , "in_io": "null"
 	\ , "out_io": "null"
 	\ }

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -323,14 +323,22 @@ function! PSCIDEgoToDefinition()
   let currentModule = s:ExtractModule()
   call s:log('PSCIDEgoToDefinition currentModule: ' . currentModule, 3)
 
-  let resp = s:callPscIde({'command': 'type', 'params': {'search': identifier, 'filters': []}, 'currentModule': currentModule}, 'Failed to get location info for: ' . identifier, 0)
+  call s:callPscIde(
+	\   {'command': 'type', 'params': {'search': identifier, 'filters': []}, 'currentModule': currentModule},
+	\ 'Failed to get location info for: ' . identifier,
+	\ 0,
+	\ { resp -> s:PSCIDEgoToDefinitionCallback(identifier, resp) }
+	\ )
+endfunction
 
-  if type(resp) == type({}) && resp.resultType ==# "success" && len(resp.result) == 1
-      call s:goToDefinition(resp.result[0].definedAt)
+function! s:PSCIDEgoToDefinitionCallback(identifier, resp)
+  call s:log("s:PSCIDEgoToDefinitionCallback: " . string(a:resp), 3)
+  if type(a:resp) == type({}) && a:resp.resultType ==# "success" && len(a:resp.result) == 1
+      call s:goToDefinition(a:resp.result[0].definedAt)
   endif
 
-  if type(resp) == type({}) && resp.resultType ==# "success" && len(resp.result) > 1
-    let choice = s:pickOption("Multiple possibilities for " . identifier, resp.result, "module")
+  if type(a:resp) == type({}) && a:resp.resultType ==# "success" && len(a:resp.result) > 1
+    let choice = s:pickOption("Multiple possibilities for " . a:identifier, a:resp.result, "module")
     if choice.picked
       call s:goToDefinition(choice.option.definedAt)
     endif

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -723,16 +723,6 @@ function! PSCIDEapplySuggestionPrime(lnr, filename, silent)
   endif
 endfunction
 
-" Remove all import qualifications
-command! -buffer PSCIDEremoveImportQualifications call PSCIDEremoveImportQualifications()
-function! PSCIDEremoveImportQualifications()
-  let captureregex = "import\\s\\(\\S\\+\\)\\s*(.*)"
-  let replace = "import \\1"
-  let command = "silent %s:" . captureregex . ":" . replace . ":g|norm!``"
-  call s:log('Executing PSCIDEremoveImportQualifications command: ' . command, 3)
-  :exe command
-endfunction
-
 " Add all import qualifications
 command! -buffer PSCIDEaddImportQualifications call PSCIDEaddImportQualifications()
 function! PSCIDEaddImportQualifications()

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -878,7 +878,7 @@ function! s:PscIdeStartCallback(input, errorm, cb, cwdcommand, cwdresp)
 
     if expectedCWD != cwdrespDecoded.result
       call s:log("s:PscIdeStartCallback: External server on incorrect CWD, closing", 1)
-      PSCIDEend
+      call PSCIDEend()
       call s:log("s:PscIdeStartCallback: Starting new server", 1)
       call PSCIDEstart(1)
     else

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -69,7 +69,6 @@ function! PSCIDEstart(silent)
     return
   endif
 
-  let g:dir = dir
   let command = [ 
 	\ "psc-ide-server",
 	\ "-p", g:psc_ide_server_port,

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -286,16 +286,14 @@ function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp)
 
     " Adding one at a time with setline + append/delete to keep line symbols and
     " cursor as intact as possible
-    call setline(1, filter(newlines, { idx -> idx < nrOfLinesToReplace }))
+    call setline(1, filter(copy(newlines), { idx -> idx < nrOfLinesToReplace }))
 
     if (nrOfLinesToDelete > 0)
-      let comm = 'silent ' . (nrOfLinesToReplace + 1) . "," . (nrOfLinesToReplace + nrOfLinesToDelete) . "d|0"
-      :exe comm
+      exe 'silent ' . (nrOfLinesToReplace + 1) . "," . (nrOfLinesToReplace + nrOfLinesToDelete) . "d_|0"
       call cursor(oldCursorPos[1] - nrOfLinesToDelete, oldCursorPos[2])
     endif
     if (nrOfLinesToAppend > 0)
-      let linesToAppend = filter(newlines, { idx -> idx >= nrOfLinesToReplace && idx < nrOfLinesToReplace + nrOfLinesToAppend })
-      call s:log('linesToAppend: ' . string(linesToAppend), 3)
+      let linesToAppend = filter(copy(newlines), { idx -> idx >= nrOfLinesToReplace && idx < nrOfLinesToReplace + nrOfLinesToAppend  })
       call append(nrOfOldlinesUnderLine, linesToAppend)
     endif
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -368,11 +368,11 @@ function! PSCIDErebuild(stuff)
 	\ input,
 	\ 0,
 	\ 0,
-	\ { msg -> s:PSCIDErebuild(filename, msg) }
+	\ { msg -> s:PSCIDErebuildCallback(filename, msg) }
 	\ )
 endfunction
 
-function! s:PSCIDErebuild(filename, resp) 
+function! s:PSCIDErebuildCallback(filename, resp) 
   if type(a:resp) == type({}) && has_key(a:resp, "resultType") 
      \ && has_key (a:resp, "result") && type(a:resp.result) == type([])
     if a:resp.resultType == "error"

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -367,17 +367,24 @@ function! s:goToDefinition(definedAt)
   endif
 endfunction
 
-function! PSCIDErebuild(stuff)
+function! PSCIDErebuild(async)
   let g:psc_ide_suggestions = {}
   let filename = expand("%:p")
   let input = {'command': 'rebuild', 'params': {'file': filename}}
 
-  call s:callPscIde(
-	\ input,
-	\ 0,
-	\ 0,
-	\ { msg -> s:PSCIDErebuildCallback(filename, msg) }
-	\ )
+  if a:async
+    call s:callPscIde(
+	  \ input,
+	  \ 0,
+	  \ 0,
+	  \ { msg -> s:PSCIDErebuildCallback(filename, msg) }
+	  \ )
+  else
+    return s:PSCIDErebuildCallback(
+	  \ filename,
+	  \ s:callPscIdeSync(input, 0, 0),
+	  \ )
+  endif
 endfunction
 
 function! s:PSCIDErebuildCallback(filename, resp) 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -637,11 +637,18 @@ command! PSCIDEpursuit call PSCIDEpursuit()
 function! PSCIDEpursuit()
   let identifier = s:GetWordUnderCursor()
 
-  let resp = s:callPscIde({'command': 'pursuit', 'params': {'query': identifier, 'type': "completion"}}, 'Failed to get pursuit info for: ' . identifier, 0)
+  call s:callPscIde(
+	\ {'command': 'pursuit', 'params': {'query': identifier, 'type': "completion"}},
+	\ 'Failed to get pursuit info for: ' . identifier,
+	\ 0,
+	\ { resp -> s:PSCIDEpursuitCallback(resp) }
+	\ )
+endfunction
 
-  if type(resp) == type({}) && resp['resultType'] ==# 'success'
-    if len(resp["result"]) > 0
-      for e in resp["result"]
+function! s:PSCIDEpuresuitCallback(resp)
+  if type(a:resp) == type({}) && a:resp['resultType'] ==# 'success'
+    if len(a:resp["result"]) > 0
+      for e in a:resp["result"]
         echom s:formatpursuit(e)
       endfor
     else
@@ -649,6 +656,7 @@ function! PSCIDEpursuit()
     endif
   endif
 endfunction
+
 function! s:formatpursuit(record)
   return "In " . s:CleanEnd(s:StripNewlines(a:record["package"])) . " " . s:CleanEnd(s:StripNewlines(a:record['module']) . '.' . s:StripNewlines(a:record['ident']) . ' :: ' . s:StripNewlines(a:record['type']))
 endfunction

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -73,8 +73,8 @@ function! PSCIDEstart(silent)
 	\ "psc-ide-server",
 	\ "-p", g:psc_ide_server_port,
 	\ "-d", dir,
-	\ "dir", "src/**/*.purs",
-	\ "dir", "bower_components/**/*.purs",
+	\ "dir", "'src/**/*.purs'",
+	\ "dir", "'bower_components/**/*.purs'",
 	\ ]
 
   exe "lcd" dir
@@ -538,7 +538,7 @@ function! PSCIDEtype()
 
   call s:getType(
 	\ identifier,
-	\ { resp -> s:PSCIDEtypeCallback(identifier, resp) }
+	\ { resp -> s:PSCIDEtypeCallback(identifier, resp.result) }
 	\ )
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -142,8 +142,18 @@ function! PSCIDEend()
   if s:pscideexternal == 1
     return
   endif
-  let input = {'command': 'quit'}
-  let resp = s:mysystem("psc-ide-client -p " . g:psc_ide_server_port, s:jsonEncode(input))
+  let filename = tempname()
+  call writefile([s:jsonEncode({'command': 'quite'})], filename)
+  call job_start(
+	\ ["psc-ide-client", "-p", g:psc_ide_server_port],
+	\ { "out_cb": function("s:PSCIDEendCallback")
+	\ , "err_cb": {err -> s:log("PSCIDEend error " . string(err), 0)}
+	\ , "in_io": "file"
+	\ , "in_name": filename
+	\ })
+endfunction
+
+function! s:PSCIDEendCallback() 
   let s:pscidestarted = 0
   let s:projectvalid = 0
 endfunction

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -143,7 +143,7 @@ function! PSCIDEend()
     return
   endif
   let filename = tempname()
-  call writefile([s:jsonEncode({'command': 'quite'})], filename)
+  call writefile([s:jsonEncode({'command': 'quit'})], filename)
   call job_start(
 	\ ["psc-ide-client", "-p", g:psc_ide_server_port],
 	\ { "out_cb": function("s:PSCIDEendCallback")
@@ -194,7 +194,7 @@ endfunction
 
 function! s:PSCIDEloadCallback(loglevel, resp)
   if type(a:resp) == type({}) && a:resp['resultType'] ==# "success"
-    call s:log("PSCIDEload: Succesfully loaded modules: " . string(a:resp["result"]), a:loglevel)
+    call s:log("PSCIDEload: Successfully loaded modules: " . string(a:resp["result"]), a:loglevel)
   else
     call s:log("PSCIDEload: Failed to load. Error: " . string(a:resp["result"]), a:loglevel)
   endif
@@ -258,7 +258,7 @@ endfunction
 
 function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp) 
   "multiple possibilities
-  call s:log("s:PSCIDEimportIndetifierCallback", 3)
+  call s:log("s:PSCIDEimportIdentifierCallback", 3)
   if type(a:resp) == type({}) && a:resp.resultType ==# "success" && type(a:resp.result[0]) == type({})
     let choice = s:pickOption("Multiple possibilities to import " . a:ident, a:resp.result, "module")
     if choice.picked

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -871,7 +871,7 @@ function! s:callPscIdeSync(input, errorm, isRetry)
 
   if s:pscidestarted == 0
 
-    let expectedCWD = s:findFileRecur('bower.json')
+    let expectedCWD = s:findRoot()
     let cwdcommand = {'command': 'cwd'}
 
     call s:log("callPscIde: No server found, looking for external server", 1)
@@ -887,7 +887,7 @@ endfunction
 
 " UTILITY FUNCTIONS ----------------------------------------------------------
 function! s:PscIdeStartCallback(input, errorm, cb, cwdcommand, cwdresp)
-  let expectedCWD = s:findFileRecur('bower.json')
+  let expectedCWD = s:findRoot()
   try
     let cwdrespDecoded = json_decode(a:cwdresp)
   catch /.*/

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -635,7 +635,7 @@ function! s:getType(identifier, cb)
 endfunction
 
 function! s:formattype(record)
-  return s:CleanEnd(s:StripNewlines(a:record['module']) . '.' . s:StripNewlines(a:record['identifier']) . ' :: ' . s:StripNewlines(a:record['type']))
+  return s:CleanEnd(s:StripNewlines(a:record['module']) . '.' . s:StripNewlines(a:record['identifier']) . ' ∷ ' . s:StripNewlines(a:record['type']))
 endfunction
 
 " APPLYSUGGESTION ------------------------------------------------------

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -352,8 +352,10 @@ function! s:PSCIDEgoToDefinitionCallback(identifier, resp)
     endif
     if choice.picked && type(choice.option.definedAt) == type({})
       call s:goToDefinition(choice.option.definedAt)
-    else
+    elseif choice.option
       echom "PSCIDE: No location information found for: " . a:identifier . " in module " . choice.option.module
+    else
+      echom "PSCIDE: No location information found for: " . a:identifier
     endif
     return
   else

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -286,7 +286,7 @@ function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp)
 
     " Adding one at a time with setline + append/delete to keep line symbols and
     " cursor as intact as possible
-    call setline(1, s:take(newlines, nrOfLinesToReplace))
+    call setline(1, filter(newlines, { idx -> idx < nrOfLinesToReplace }))
 
     if (nrOfLinesToDelete > 0)
       let comm = 'silent ' . (nrOfLinesToReplace + 1) . "," . (nrOfLinesToReplace + nrOfLinesToDelete) . "d|0"
@@ -294,7 +294,7 @@ function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp)
       call cursor(oldCursorPos[1] - nrOfLinesToDelete, oldCursorPos[2])
     endif
     if (nrOfLinesToAppend > 0)
-      let linesToAppend = s:take(s:drop(newlines, nrOfLinesToReplace), nrOfLinesToAppend)
+      let linesToAppend = filter(neslines, { idx -> idx >= nrOfLinesToReplace && idx < nrOfLinesToReplace + nrOfLinesToAppend })
       call s:log('linesToAppend: ' . string(linesToAppend), 3)
       call append(nrOfOldlinesUnderLine, linesToAppend)
     endif
@@ -303,24 +303,6 @@ function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp)
   else
     call s:log("PSCIDEimportIdentifier: Failed to import identifier " . a:ident . ". Error: " . string(a:resp["result"]), 0)
   endif
-endfunction
-
-function! s:take(list, j)
-  let newlist = []
-  for i in range(0, a:j - 1)
-    call add(newlist, a:list[i])
-  endfor
-  return newlist
-endfunction
-
-function! s:drop(list, j)
-  let newlist = []
-  for i in range(0, len(a:list) - 1)
-    if i >= a:j
-      call add(newlist, a:list[i])
-    endif
-  endfor
-  return newlist
 endfunction
 
 command! PSCIDEgoToDefinition call PSCIDEgoToDefinition()

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -144,10 +144,10 @@ function! PSCIDEend()
   endif
   let filename = tempname()
   call writefile([s:jsonEncode({'command': 'quit'})], filename)
-  call job_start(
+  return job_start(
 	\ ["psc-ide-client", "-p", g:psc_ide_server_port],
-	\ { "out_cb": function("s:PSCIDEendCallback")
-	\ , "err_cb": {err -> s:log("PSCIDEend error " . string(err), 0)}
+	\ { "exit_cb": {job, status -> s:PSCIDEendCallback() }
+	\ , "err_cb": {err -> s:log("PSCIDEend error: " . string(err), 0)}
 	\ , "in_io": "file"
 	\ , "in_name": filename
 	\ })

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -678,7 +678,7 @@ endfunction
 " LIST -----------------------------------------------------------------------
 command! PSCIDElist call PSCIDElist()
 function! PSCIDElist()
-  s:callPscIde(
+  let resp = s:callPscIdeSync(
 	\ {'command': 'list', 'params': {'type': 'loadedModules'}},
 	\ 'Failed to get loaded modules',
 	\ 0
@@ -723,7 +723,10 @@ function! PSCIDEomni(findstart,base)
     let currentModule = s:ExtractModule()
     call s:log('PSCIDEOmni currentModule: ' . currentModule, 3)
 
-    let resp = s:callPscIde({'command': 'complete', 'params': {'filters': [s:prefixFilter(str)], 'matcher': s:flexMatcher(str), 'currentModule': currentModule}}, 'Failed to get completions for: '. str, 0)
+    let resp = s:callPscIdeSync(
+	  \ {'command': 'complete', 'params': {'filters': [s:prefixFilter(str)], 'matcher': s:flexMatcher(str), 'currentModule': currentModule}},
+	  \ 'Failed to get completions for: '. str,
+	  \ 0)
 
     if type(resp) == type({}) && resp.resultType ==# 'success'
       call s:log('PSCIDEOmni: Found Entries: ' . string(resp.result), 3)

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -475,14 +475,24 @@ function! PSCIDEcaseSplit()
   call s:log('end position: ' . string(e), 3)
   call s:log('type: ' . t, 3)
 
-  let command = {'command': 'caseSplit', 'params': {'line': line, 'begin': b, 'end': e, 'annotations': s:jsonFalse(), 'type': t}}
+  let command = {
+	\ 'command': 'caseSplit',
+	\ 'params': { 'line': line, 'begin': b, 'end': e, 'annotations': s:jsonFalse(), 'type': t}
+	\ }
 
-  let resp = s:callPscIde(command, 'Failed to split case for: ' . word, 0)
+  call s:callPscIde(
+	\ command,
+	\ 'Failed to split case for: ' . word,
+	\ 0,
+	\ { resp -> s:PSCIDEcaseSplitCallback(lnr, resp) }
+	\ )
+endfunction
 
-  if type(resp) == type({}) && resp['resultType'] ==# 'success' && type(resp.result) == type([])     
-    call s:log('PSCIDEcaseSplit results: ' . string(resp.result), 3)
-    call append(lnr, resp.result)
-    :normal dd
+function! s:PSCIDEcaseSplitCallback(lnr, resp)
+  if type(a:resp) == type({}) && a:resp['resultType'] ==# 'success' && type(a:resp.result) == type([])     
+    call s:log('PSCIDEcaseSplit results: ' . string(a:resp.result), 3)
+    call append(a:lnr, a:resp.result)
+    normal dd
   endif
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1140,16 +1140,13 @@ endfunction
 
 
 fun! s:jsonNULL()
-  return {'json_special_value': 'null'}
+  return v:null
 endf
 fun! s:jsonTrue()
-  return {'json_special_value': 'true'}
+  return v:true
 endf
 fun! s:jsonFalse()
-  return {'json_special_value': 'false'}
-endf
-fun! s:jsonToJSONBool(i)
-  return  a:i ? s:jsonTrue() : s:jsonFalse()
+  return v:false
 endf
 
 " Parse Errors & Suggestions ------------------------------------------

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -824,6 +824,29 @@ function! s:callPscIde(input, errorm, isRetry, cb)
   call delete(tempfile)
 endfunction
 
+function! s:callPscIdeSync(input, errorm, isRetry) 
+  call s:log("callPscIde: start: Executing command: " . string(a:input), 3)
+
+  if s:projectvalid == 0
+    call PSCIDEprojectValidate()
+  endif
+
+  if s:pscidestarted == 0
+
+    let expectedCWD = s:findFileRecur('bower.json')
+    let cwdcommand = {'command': 'cwd'}
+
+    call s:log("callPscIde: No server found, looking for external server", 1)
+    let cwdresp = s:mysystem("psc-ide-client -p " . g:psc_ide_server_port, s:jsonEncode(cwdcommand))
+    call s:PscIdeStartCallback(cwdcommand, cwdresp)
+  endif
+
+  call s:log("callPscIde: Trying to reach server again", 1)
+  let enc = s:jsonEncode(a:input)
+  let resp = s:mysystem("psc-ide-client -p " . g:psc_ide_server_port, enc)
+  return s:PscIdeCallback(a:input, a:errorm, a:isRetry, resp)
+endfunction
+
 " UTILITY FUNCTIONS ----------------------------------------------------------
 function! s:PscIdeStartCallback(cwdcommand, cwdresp)
   let expectedCWD = s:findFileRecur('bower.json')

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -69,8 +69,7 @@ function! PSCIDEstart(silent)
     return
   endif
 
-  call s:log("PSCIDEstart: Starting psc-ide-server at " . dir . " on port " . g:psc_ide_server_port, loglevel)
-
+  let g:dir = dir
   let command = [ 
 	\ "psc-ide-server",
 	\ "-p", g:psc_ide_server_port,
@@ -777,7 +776,7 @@ function! PSCIDEomni(findstart,base)
       for entry in entries
         if entry['identifier'] =~ '^' . str
           let e = {'word': entry['identifier'], 'menu': s:StripNewlines(entry['type']), 'info': entry['module'], 'dup': 0}
-          let existing = s:findInListBy(result, 'word', e['word'])
+          let existing = filter(result, {idx, val -> val["word"] == e["word"]})
 
           if existing != {}
             let e['menu'] = e['menu'] . ' (' . e['info'] . ')'
@@ -794,21 +793,6 @@ function! PSCIDEomni(findstart,base)
     endif
     return result
   endif
-endfunction
-
-function! s:findInListBy(list, key, str)
-  let i = 0
-  let l = len(a:list)
-  let found = {}
-  
-  while found == {} && i < l
-    if a:list[i][a:key] == a:str
-      let found = a:list[i]
-    endif
-    let i = i + 1
-  endwhile
-
-  return found
 endfunction
 
 function! s:prefixFilter(s) 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -416,10 +416,17 @@ endfunction
 " Get current working directory of psc-ide-server
 command! PSCIDEcwd call PSCIDEcwd()
 function! PSCIDEcwd()
-  let resp = s:callPscIde({'command': 'cwd'}, "Failed to get current working directory", 0)
+  call s:callPscIde(
+	\ {'command': 'cwd'},
+	\ "Failed to get current working directory", 
+	\ 0,
+	\ function("s:PSCIDEcwdCallback")
+	\ )
+endfunction
 
-  if type(resp) == type({}) && resp['resultType'] ==# 'success'
-    echom "PSC-IDE: Current working directory: " . resp["result"]
+function s:PSCIDEcwdCallback(resp)
+  if type(a:resp) == type({}) && a:resp['resultType'] ==# 'success'
+    echom "PSC-IDE: Current working directory: " . a:resp["result"]
   endif
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -868,7 +868,7 @@ function! s:callPscIde(input, errorm, isRetry, cb)
 	\ { "out_cb": {ch, msg -> a:cb(s:PscIdeCallback(a:input, a:errorm, a:isRetry, a:cb, msg))}
 	\ , "in_io": "file"
 	\ , "in_name": tempfile
-	\ , "err_cb": {ch, err -> s:log("s:callPscIde error: " . err, 3)}
+	\ , "err_cb": {ch, err -> s:log("s:callPscIde error: " . string(err), 3)}
 	\ })
   call delete(tempfile)
 endfunction
@@ -1012,7 +1012,7 @@ function! s:PscIdeCallback(input, errorm, isRetry, cb, resp)
     endif
   endif
 
-  let decoded = json_decode(s:CleanEnd(s:StripNewlines(a:resp)))
+  let decoded = json_decode(a:resp)
   call s:log("s:PscIdeCallback: Decoded response: " . string(decoded), 3)
 
   if (type(decoded) != type({}) || decoded['resultType'] !=# 'success') 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -94,7 +94,6 @@ function! PSCIDEstart(silent)
 endfunction
 
 function! s:onServerExit(ch, msg, ev)
-  call s:log("purs ide server exited: " . string(ev), 0)
   let s:pscidestarted = 0
 endfunction
 
@@ -149,8 +148,7 @@ function! PSCIDEend()
 	\ { "on_exit": {job, status, ev -> s:PSCIDEendCallback() }
 	\ , "on_stderr": {err -> s:log("PSCIDEend error: " . string(err), 0)}
 	\ })
-  call async#job#send(jobid, json_encode({'command': 'quit'}))
-  call async#job#stop(jobid)
+  call async#job#send(jobid, json_encode({'command': 'quit'}) . "\n")
 endfunction
 
 function! s:PSCIDEendCallback() 
@@ -922,7 +920,7 @@ function! s:callPscIde(input, errorm, isRetry, cb)
 	  \ { "on_stdout": {ch, msg -> s:PscIdeStartCallback(a:input, a:errorm, a:cb, cwdcommand, msg)}
 	  \ , "on_stderr": {ch, err -> s:log("s:callPscIde error: " . string(err), 3)}
 	  \ })
-    call async#job#stop(jobid)
+    call async#job#send(jobid, json_encode(cwdcommand) . "\n")
     return
   endif
 
@@ -933,12 +931,12 @@ function! s:callPscIde(input, errorm, isRetry, cb)
 	\ { "on_stdout": {ch, msg -> a:cb(s:PscIdeCallback(a:input, a:errorm, a:isRetry, a:cb, msg))}
 	\ , "on_stderr": {ch, err -> s:log("s:callPscIde error: " . string(err), 0)}
 	\ })
-  call async#job#send(jobid, enc ."\n")
-  " call async#job#stop(jobid)
+  call async#job#send(jobid, enc . "\n")
+  " call async#job#stop(jobid) " Not needed I think, \n stops job
 endfunction
 
 function! s:callPscIdeSync(input, errorm, isRetry)
-  call s:log("callPscIde: start: Executing command: " . string(a:input), 3)
+  call s:log("callPscIdeSync: start: Executing command: " . string(a:input), 3)
 
   if s:projectvalid == 0
     call PSCIDEprojectValidate()
@@ -1003,14 +1001,20 @@ function! s:PscIdeStartCallback(input, errorm, cb, cwdcommand, cwdresp)
 	\ { "on_stdout": { ch, resp -> s:PscIdeRetryCallback(a:input, a:errorm, a:cb, expectedCWD, resp) }
 	\ , "on_stderr": { ch, err -> s:log("s:PscIdeStartCallback error: " . err, 3) }
 	\ })
-  call async#job#send(jobid, json_encode(a:cwdcommand))
-  call async#job#stop(jobid)
+  call async#job#send(jobid, json_encode(a:cwdcommand) . "\n")
 endfunction
 
 function! s:PscIdeRetryCallback(input, errorm, cb, expectedCWD, cwdresp2)
-  call s:log("s:PscIdeRetryCallback: Raw response of trying to reach server again: " . a:cwdresp2, 1)
+  call s:log("s:PscIdeRetryCallback: Raw response of trying to reach server again: " . string(a:cwdresp2), 1)
+
+  if (type(a:cwdresp2) == type([]))
+    let json = a:cwdresp2[0]
+  else
+    let json = a:cwdresp2
+  endif
+
   try
-    let cwdresp2Decoded = json_decode(a:cwdresp2)
+    let cwdresp2Decoded = json_decode(json)
   catch /.*/
     let cwdresp2Decoded = {"resultType": "failed", "error": a:cwdresp2}
   endtry
@@ -1049,8 +1053,7 @@ function! s:PscIdeRetryCallback(input, errorm, cb, expectedCWD, cwdresp2)
 	\ { "on_stdout": {ch, resp -> a:cb(s:PscIdeCallback(a:input, a:errorm, 1, a:cb, resp))}
 	\ , "on_stderr": {ch, err -> s:log("s:PscIdeRetryCallback error: " . err, 3)}
 	\ })
-  call async#job#send(jobid, enc)
-  call async#job#stop(jobid)
+  call async#job#send(jobid, enc . "\n")
 endfunction
 
 function! s:PscIdeCallback(input, errorm, isRetry, cb, resp)

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -420,9 +420,10 @@ function! PSCIDEaddTypeAnnotation()
 endfunction
 
 function! s:PSCIDEaddTypeAnnotationCallback(identifier, resp)
-  if type(a:resp) == type([])
+  if type(a:resp) == v:t_dict && a:resp["resultType"] ==# 'success' && !empty(a:resp["result"])
+    let result = a:resp["result"]
     let lnr = line(".")
-    call append(lnr - 1, s:StripNewlines(a:resp[0]['identifier']) . ' :: ' . s:StripNewlines(a:resp[0]["type"]))
+    call append(lnr - 1, s:StripNewlines(result[0]['identifier']) . ' :: ' . s:StripNewlines(result[0]["type"]))
   else
     echom "PSC-IDE: No type information found for " . a:identifier
   endif
@@ -542,16 +543,8 @@ function! s:getType(identifier, cb)
 	\ {'command': 'type', 'params': {'search': a:identifier, 'filters': []}, 'currentModule': currentModule},
 	\  'Failed to get type info for: ' . a:identifier,
 	\ 0,
-	\ { resp -> s:getTypeCallback(resp, a:cb)}
+	\ {resp -> a:cb(resp)}
 	\ )
-endfunction
-
-function! s:getTypeCallback(resp, cb)
-  if type(a:resp) == type({}) && a:resp['resultType'] ==# 'success'
-    if len(a:resp["result"]) > 0
-      call a:cb(a:resp["result"])
-    endif
-  endif
 endfunction
 
 function! s:formattype(record)

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -436,9 +436,9 @@ function! PSCIDEaddTypeAnnotation()
 endfunction
 
 function! s:PSCIDEaddTypeAnnotationCallback(identifier, resp)
-  if type(a:result) == type([])
+  if type(a:resp) == type([])
     let lnr = line(".")
-    call append(lnr - 1, s:StripNewlines(result[0]['identifier']) . ' :: ' . s:StripNewlines(result[0]["type"]))
+    call append(lnr - 1, s:StripNewlines(a:resp[0]['identifier']) . ' :: ' . s:StripNewlines(a:resp[0]["type"]))
   else
     echom "PSC-IDE: No type information found for " . a:identifier
   endif

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -657,7 +657,7 @@ function! s:getType(identifier, cb)
   call s:log('PSCIDE s:getType currentModule: ' . currentModule, 3)
 
   call s:callPscIde(
-	\ {'command': 'type', 'params': {'search': a:identifier, 'filters': [{'filter': 'modules' , 'params': {'modules': importedModules } }]}, 'currentModule': currentModule},
+	\ {'command': 'type', 'params': {'search': a:identifier, 'filters': [{'filter': 'modules' , 'params': {'modules': importedModules } }], 'currentModule': currentModule}},
 	\  'Failed to get type info for: ' . a:identifier,
 	\ 0,
 	\ {resp -> a:cb(resp)}

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -73,8 +73,8 @@ function! PSCIDEstart(silent)
 	\ "psc-ide-server",
 	\ "-p", g:psc_ide_server_port,
 	\ "-d", dir,
-	\ "dir", "'src/**/*.purs'",
-	\ "dir", "'bower_components/**/*.purs'",
+	\ "src/**/*.purs",
+	\ "bower_components/**/*.purs",
 	\ ]
 
   exe "lcd" dir

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -332,15 +332,16 @@ function! s:PSCIDEgoToDefinitionCallback(identifier, resp)
   call s:log("s:PSCIDEgoToDefinitionCallback", 3)
   let results = []
   for res in a:resp.result
-    if empty(filter(copy(results), { idx, val -> val.definedAt.name == res.definedAt.name && val.definedAt.start[0] == res.definedAt.start[0] && val.definedAt.start[1] == res.definedAt.start[1]}))
+    if empty(filter(copy(results), { idx, val -> 
+	  \    val.definedAt != v:null
+	  \ && res.definedAt != v:null
+	  \ && val.definedAt.name == res.definedAt.name
+	  \ && val.definedAt.start[0] == res.definedAt.start[0]
+	  \ && val.definedAt.start[1] == res.definedAt.start[1]}))
       call add(results, res)
     endif
   endfor
-  if type(a:resp) == type({}) && a:resp.resultType ==# "success" && len(a:resp.result) == 1
-      call s:goToDefinition(results[0].definedAt)
-  endif
-
-  if type(a:resp) == type({}) && a:resp.resultType ==# "success"
+  if type(a:resp) == v:t_dict && a:resp.resultType ==# "success"
     if len(results) > 1
       let choice = s:pickOption("Multiple possibilities for " . a:identifier, results, "module")
     elseif len(results) == 1
@@ -350,12 +351,11 @@ function! s:PSCIDEgoToDefinitionCallback(identifier, resp)
     endif
     if choice.picked && type(choice.option.definedAt) == type({})
       call s:goToDefinition(choice.option.definedAt)
-    elseif choice.option
+    elseif type(choice.option) == v:t_dict
       echom "PSCIDE: No location information found for: " . a:identifier . " in module " . choice.option.module
     else
       echom "PSCIDE: No location information found for: " . a:identifier
     endif
-    return
   else
     echom "PSCIDE: No location information found for: " . a:identifier
   endif

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -439,12 +439,19 @@ function! PSCIDEaddClause()
 
   let command = {'command': 'addClause', 'params': {'line': line, 'annotations': s:jsonFalse()}}
 
-  let resp = s:callPscIde(command, "Failed to add clause", 0)
+  call s:callPscIde(
+	\ command,
+	\ "Failed to add clause",
+	\ 0,
+	\ { resp -> s:PSCIDEaddClauseCallback(lnr, resp) }
+	\ )
+endfunction
 
-  if type(resp) == type({}) && resp['resultType'] ==# 'success' && type(resp.result) == type([])     
-    call s:log('PSCIDEaddClause results: ' . string(resp.result), 3)
-    call append(lnr, resp.result)
-    :normal dd
+function! s:PSCIDEaddClauseCallback(lnr, resp)
+  if type(a:resp) == type({}) && a:resp['resultType'] ==# 'success' && type(a:resp.result) == type([])     
+    call s:log('PSCIDEaddClause results: ' . string(a:resp.result), 3)
+    call append(a:lnr, a:resp.result)
+    normal dd
   endif
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -653,7 +653,7 @@ endfunction
 
 function! s:getType(identifier, cb)
   let currentModule = s:ExtractModule()
-  let importedModules = map(s:ListImports(currentModule), {key, val -> val["module"]}) 
+  let importedModules = add(map(s:ListImports(currentModule), {key, val -> val["module"]}), currentModule)
   call s:log('PSCIDE s:getType currentModule: ' . currentModule, 3)
 
   call s:callPscIde(

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -55,7 +55,7 @@ let s:psc_ide_server = v:none
 "Looks for bower.json, assumes that's the root directory, starts
 "psc-ide-server in the background
 "Returns Nothing
-command! PSCIDEstart call PSCIDEstart(0)
+command! -buffer PSCIDEstart call PSCIDEstart(0)
 function! PSCIDEstart(silent)
   if s:pscidestarted == 1 
     return
@@ -135,7 +135,7 @@ endfunction
 
 " END ------------------------------------------------------------------------
 " Tell the psc-ide-server to quit
-command! PSCIDEend call PSCIDEend()
+command! -buffer PSCIDEend call PSCIDEend()
 function! PSCIDEend()
   if s:pscideexternal == 1
     return
@@ -176,7 +176,7 @@ endfunction
 
 " LOAD -----------------------------------------------------------------------
 " Load module of current buffer + its dependencies into psc-ide-server
-command! PSCIDEload call PSCIDEload(0)
+command! -buffer PSCIDEload call PSCIDEload(0)
 function! PSCIDEload(silent)
   let loglevel = a:silent == 1 ? 1 : 0
 
@@ -216,7 +216,7 @@ function! s:ExtractModule()
 endfunction
 
 " Import given identifier
-command! PSCIDEimportIdentifier call PSCIDEimportIdentifier()
+command! -buffer PSCIDEimportIdentifier call PSCIDEimportIdentifier()
 function! PSCIDEimportIdentifier()
   call s:importIdentifier(s:GetWordUnderCursor(), "")
 endfunction
@@ -305,7 +305,7 @@ function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp)
   endif
 endfunction
 
-command! PSCIDEgoToDefinition call PSCIDEgoToDefinition()
+command! -buffer PSCIDEgoToDefinition call PSCIDEgoToDefinition()
 function! PSCIDEgoToDefinition()
   let identifier = s:GetWordUnderCursor()
   call s:log('PSCIDEgoToDefinition identifier: ' . identifier, 3)
@@ -409,7 +409,7 @@ function! s:PSCIDErebuildCallback(filename, resp)
 endfunction
 
 " Add type annotation
-command! PSCIDEaddTypeAnnotation call PSCIDEaddTypeAnnotation()
+command! -buffer PSCIDEaddTypeAnnotation call PSCIDEaddTypeAnnotation()
 function! PSCIDEaddTypeAnnotation()
   let identifier = s:GetWordUnderCursor()
 
@@ -431,7 +431,7 @@ endfunction
 
 " CWD ------------------------------------------------------------------------
 " Get current working directory of psc-ide-server
-command! PSCIDEcwd call PSCIDEcwd()
+command! -buffer PSCIDEcwd call PSCIDEcwd()
 function! PSCIDEcwd()
   call s:callPscIde(
 	\ {'command': 'cwd'},
@@ -449,7 +449,7 @@ endfunction
 
 " ADDCLAUSE
 " Makes template function implementation from signature
-command! PSCIDEaddClause call PSCIDEaddClause()
+command! -buffer PSCIDEaddClause call PSCIDEaddClause()
 function! PSCIDEaddClause()
   let lnr = line(".")
   let line = getline(lnr)
@@ -475,7 +475,7 @@ endfunction
 " CASESPLIT
 " Hover cursor over variable in function declaration -> pattern match on all
 " different cases of the variable
-command! PSCIDEcaseSplit call PSCIDEcaseSplit()
+command! -buffer PSCIDEcaseSplit call PSCIDEcaseSplit()
 function! PSCIDEcaseSplit()
   let lnr = line(".")
   let line = getline(lnr)
@@ -515,7 +515,7 @@ endfunction
 
 " TYPE -----------------------------------------------------------------------
 " Get type of word under cursor
-command! PSCIDEtype call PSCIDEtype()
+command! -buffer PSCIDEtype call PSCIDEtype()
 function! PSCIDEtype()
   let identifier = s:GetWordUnderCursor()
 
@@ -553,7 +553,7 @@ endfunction
 
 " APPLYSUGGESTION ------------------------------------------------------
 " Apply suggestion in loclist to buffer --------------------------------
-command! PSCIDEapplySuggestion call PSCIDEapplySuggestion()
+command! -buffer PSCIDEapplySuggestion call PSCIDEapplySuggestion()
 function! PSCIDEapplySuggestion()
   let lnr = line(".")
   let filename = expand("%:p")
@@ -608,7 +608,7 @@ function! PSCIDEapplySuggestionPrime(lnr, filename, silent)
 endfunction
 
 " Remove all import qualifications
-command! PSCIDEremoveImportQualifications call PSCIDEremoveImportQualifications()
+command! -buffer PSCIDEremoveImportQualifications call PSCIDEremoveImportQualifications()
 function! PSCIDEremoveImportQualifications()
   let captureregex = "import\\s\\(\\S\\+\\)\\s*(.*)"
   let replace = "import \\1"
@@ -618,7 +618,7 @@ function! PSCIDEremoveImportQualifications()
 endfunction
 
 " Add all import qualifications
-command! PSCIDEaddImportQualifications call PSCIDEaddImportQualifications()
+command! -buffer PSCIDEaddImportQualifications call PSCIDEaddImportQualifications()
 function! PSCIDEaddImportQualifications()
   let foundLines = []
   let filename = expand("%:p")
@@ -642,7 +642,7 @@ endfunction
 
 
 " PURSUIT --------------------------------------------------------------------
-command! PSCIDEpursuit call PSCIDEpursuit()
+command! -buffer PSCIDEpursuit call PSCIDEpursuit()
 function! PSCIDEpursuit()
   let identifier = s:GetWordUnderCursor()
 
@@ -671,7 +671,7 @@ function! s:formatpursuit(record)
 endfunction
 
 " VALIDATE -----------------------------------------------------------------------
-command! PSCIDEprojectValidate call PSCIDEprojectValidate()
+command! -buffer PSCIDEprojectValidate call PSCIDEprojectValidate()
 function! PSCIDEprojectValidate()
   let problems = s:projectProblems()
 
@@ -685,7 +685,7 @@ function! PSCIDEprojectValidate()
 endfunction
 
 " LIST -----------------------------------------------------------------------
-command! PSCIDElist call PSCIDElist()
+command! -buffer PSCIDElist call PSCIDElist()
 function! PSCIDElist()
   let resp = s:callPscIdeSync(
 	\ {'command': 'list', 'params': {'type': 'loadedModules'}},

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -653,7 +653,7 @@ endfunction
 
 function! s:getType(identifier, cb)
   let currentModule = s:ExtractModule()
-  let importedModules = map(s:ListImports(currentModule), {key, val -> val["module"]}) 
+  let importedModules = add(map(s:ListImports(currentModule), {key, val -> val["module"]}), currentModule) 
   call s:log('PSCIDE s:getType currentModule: ' . currentModule, 3)
 
   call s:callPscIde(

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -562,7 +562,14 @@ command! PSCIDElistImports call PSCIDElistImports()
 function! PSCIDElistImports()
   let currentModule = s:ExtractModule()
   call s:log('PSCIDElistImports ' . currentModule, 3)
-  call s:ListImports(currentModule)
+  let imports =  s:ListImports(currentModule)
+  for import in imports
+    call s:EchoImport(import)
+  endfor
+  if (len(imports) == 0)
+    echom "PSC-IDE: No import information found for " . currentModule
+  endif
+
 endfunction
 
 function! s:EchoImport(import)
@@ -607,20 +614,14 @@ function! s:ListImports(module)
   " Only need module names right now, so pluck just those.
   if type(resp) == type({}) && resp['resultType'] ==# 'success'
     " psc-ide >=0.11 returns imports on 'imports' property.
-    let imports = type(resp['result']) == type([]) ? resp['result'] : resp['result']['imports']
-    if len(imports) > 0
-      for import in imports
-	call s:EchoImport(import)
-      endfor
-    else
-      echom "purs ide: No import information found for " . a:module
+    return type(resp['result']) == type([]) ? resp['result'] : resp['result']['imports']
     endif
   endif
 endfunction
 
-function! s:getType(identifier)
+function! s:getType(identifier, cb)
   let currentModule = s:ExtractModule()
-  let importedModules = s:ListImports(currentModule)
+  let importedModules = map(s:ListImports(currentModule), {key, val -> val["module"]}) 
   call s:log('PSCIDE s:getType currentModule: ' . currentModule, 3)
 
   call s:callPscIde(

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -297,14 +297,16 @@ function! s:PSCIDEimportIdentifierCallback(ident, id, module, resp)
     " Adding one at a time with setline + append/delete to keep line symbols and
     " cursor as intact as possible
     let view = winsaveview()
-    call setline(1, filter(copy(newlines), { idx -> idx < nrOfLinesToReplace }))
+    call setline(1, filter(copy(newlines), { idx -> idx < nrOfLinesToReplace + nrOfLinesToAppend }))
 
     if (nrOfLinesToDelete > 0)
+      let view["lnum"] -= nrOfLinesToDelete
       exe 'silent ' . (nrOfLinesToReplace + 1) . "," . (nrOfLinesToReplace + nrOfLinesToDelete) . "d_|0"
     endif
     if (nrOfLinesToAppend > 0)
-      let view = winsaveview()
-      let linesToAppend = filter(copy(newlines), { idx -> idx >= nrOfLinesToReplace && idx < nrOfLinesToReplace + nrOfLinesToAppend  })
+      let linesToAppend = filter(copy(newlines), { idx -> idx > nrOfLinesToReplace && idx <= nrOfLinesToReplace + nrOfLinesToAppend  })
+      let view["lnum"] += nrOfLinesToAppend
+      call append(line("."), linesToAppend)
     endif
     call winrestview(view)
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -775,7 +775,7 @@ function! PSCIDEomni(findstart,base)
       for entry in entries
         if entry['identifier'] =~ '^' . str
           let e = {'word': entry['identifier'], 'menu': s:StripNewlines(entry['type']), 'info': entry['module'], 'dup': 0}
-          let existing = filter(result, {idx, val -> val["word"] == e["word"]})
+          let existing = s:findInListBy(result, 'word', e['word'])
 
           if existing != {}
             let e['menu'] = e['menu'] . ' (' . e['info'] . ')'
@@ -792,6 +792,21 @@ function! PSCIDEomni(findstart,base)
     endif
     return result
   endif
+endfunction
+
+function! s:findInListBy(list, key, str)
+  let i = 0
+  let l = len(a:list)
+  let found = {}
+  
+  while found == {} && i < l
+    if a:list[i][a:key] == a:str
+      let found = a:list[i]
+    endif
+    let i = i + 1
+  endwhile
+
+  return found
 endfunction
 
 function! s:prefixFilter(s) 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -75,9 +75,11 @@ function! PSCIDEstart(silent)
 	\ "psc-ide-server",
 	\ "-p", g:psc_ide_server_port,
 	\ "-d", dir,
-	\ "dir", "/src/**/*.purs",
-	\ "dir", "/bower_components/**/*.purs",
+	\ "dir", "src/**/*.purs",
+	\ "dir", "bower_components/**/*.purs",
 	\ ]
+
+  exe "lcd" dir
   let s:psc_ide_server = job_start(
 	\ command,
 	\ { "stoponexit": "term"
@@ -87,6 +89,7 @@ function! PSCIDEstart(silent)
 	\ , "out_io": "null"
 	\ }
 	\ )
+  lcd -
 
   call s:log("PSCIDEstart: Sleeping for 100ms so server can start up", 1)
   sleep 100m

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -678,11 +678,18 @@ endfunction
 " LIST -----------------------------------------------------------------------
 command! PSCIDElist call PSCIDElist()
 function! PSCIDElist()
-  let resp = s:callPscIde({'command': 'list', 'params': {'type': 'loadedModules'}}, 'Failed to get loaded modules', 0)
+  s:callPscIde(
+	\ {'command': 'list', 'params': {'type': 'loadedModules'}},
+	\ 'Failed to get loaded modules',
+	\ 0
+	\ )
+  call s:PSCIDElistCallback(resp)
+endfunction
 
-  if type(resp) == type({}) && resp['resultType'] ==# 'success'
-    if len(resp["result"]) > 0
-      for m in resp["result"]
+function s:PSCIDElistCallback(resp)
+  if type(a:resp) == type({}) && a:resp['resultType'] ==# 'success'
+    if len(a:resp["result"]) > 0
+      for m in a:resp["result"]
         echom m
       endfor
     else
@@ -690,7 +697,6 @@ function! PSCIDElist()
     endif
   endif
 endfunction
-
 
 " SET UP OMNICOMPLETION ------------------------------------------------------
 set omnifunc=PSCIDEomni

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -193,7 +193,7 @@ function! s:PSCIDEloadCallback(loglevel, resp)
   if type(a:resp) == type({}) && a:resp['resultType'] ==# "success"
     call s:log("PSCIDEload: Successfully loaded modules: " . string(a:resp["result"]), a:loglevel)
   else
-    call s:log("PSCIDEload: Failed to load. Error: " . string(a:resp["result"]), a:loglevel)
+    call s:log("PSCIDEload: Failed to load. Error.", a:loglevel)
   endif
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -377,22 +377,30 @@ function! s:goToDefinition(definedAt)
   endif
 endfunction
 
-function! PSCIDErebuild(async)
+function! PSCIDErebuild(async, ...)
   let g:psc_ide_suggestions = {}
   let filename = expand("%:p")
   let input = {'command': 'rebuild', 'params': {'file': filename}}
+
+  if a:0 > 0 && type(a:1) == v:t_func
+    let CallBack = a:1
+  else
+    let CallBack = {resp -> resp}
+  endif
 
   if a:async
     call s:callPscIde(
 	  \ input,
 	  \ 0,
 	  \ 0,
-	  \ { msg -> s:PSCIDErebuildCallback(filename, msg) }
+	  \ { msg -> CallBack(s:PSCIDErebuildCallback(filename, msg)) }
 	  \ )
   else
-    return s:PSCIDErebuildCallback(
-	  \ filename,
-	  \ s:callPscIdeSync(input, 0, 0),
+    return CallBack(
+	    s:PSCIDErebuildCallback(
+	      \ filename,
+	      \ s:callPscIdeSync(input, 0, 0),
+	      \ )
 	  \ )
   endif
 endfunction

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -333,8 +333,8 @@ function! s:PSCIDEgoToDefinitionCallback(identifier, resp)
   let results = []
   for res in a:resp.result
     if empty(filter(copy(results), { idx, val -> 
-	  \    val.definedAt != v:null
-	  \ && res.definedAt != v:null
+	  \    type(val.definedAt) == v:t_dict
+	  \ && type(res.definedAt) != v:t_dict
 	  \ && val.definedAt.name == res.definedAt.name
 	  \ && val.definedAt.start[0] == res.definedAt.start[0]
 	  \ && val.definedAt.start[1] == res.definedAt.start[1]}))

--- a/syntax_checkers/purescript/pscide.vim
+++ b/syntax_checkers/purescript/pscide.vim
@@ -47,7 +47,8 @@ function! SyntaxCheckers_purescript_pscide_GetLocList() dict
     let loclist = SyntasticMake({
         \ 'makeprg': self.makeprgBuild({'exe': 'echo', 'args': 'a'}), 
         \ 'errorformat': '%t:%f:%l:%c:%m',
-        \ 'Preprocess': function('PSCIDErebuild') })
+        \ 'Preprocess': {args -> PSCIDErebuild(0)}
+	\ })
   endif
 
   if g:psc_ide_syntastic_mode == 2


### PR DESCRIPTION
The only sync command is `:PSCIDElist` as it outputs lots of input, and the omni-completion.
Otherwise all commands run in non-blocking way.

The syntastic is lacking support for async commands, `PSCIDErebuild` can be run in both blocking and non-blocking way.  The non-blocking way might be useful for people who don't want to use syntastic.