### PR TITLE
updates

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1155,8 +1155,12 @@ fun! s:searchFn(resp)
     if bufnr != -1
       let llentry.bufnr = bufnr
     endif
+    let module = get(res, "module", "")
+    if empty(module)
+      let module = ""
+    endif
     let llentry.filename = printf("%-" . filePadding . "s", res.definedAt.name)
-    let llentry.module = printf("%-" . modulePadding . "s", res.module)
+    let llentry.module = printf("%-" . modulePadding . "s", module)
     let llentry.lnum = res.definedAt.start[0]
     let llentry.col = res.definedAt.start[1]
     let llentry.text = printf("%s %s", res.identifier, res.type)
@@ -1323,8 +1327,12 @@ function! s:qfEntry(e, filename, err)
 	\ ? a:e.position.startColumn : 1
   let colend = has_key(a:e, "position") && type(a:e.position) == v:t_dict
   \ ? a:e.position.endColumn : 1
+  let module = get(a:e, "moduleName", "")
+  if empty(module)
+    let module = ""
+  endif
   return  { "filename": a:filename
-	\ , "module": get(a:e, "moduleName", "")
+	\ , "module": module
 	\ , "bufnr": bufnr(a:filename)
 	\ , "lnum": lnum
 	\ , "lnumend": lnumend

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1253,6 +1253,9 @@ function! PSCIDEerrors(llist, ...)
     let silent = v:false
   endif
 
+  let filePadding = min([max(map(copy(a:llist), { i, r -> len(r.filename)})) + 1, 30])
+  let modulePadding = min([max(map(copy(a:llist), { i, r -> len(r.module)})) + 1, 30])
+
   let qfList = []
   for e in a:llist
     if e.bufnr != -1
@@ -1260,7 +1263,8 @@ function! PSCIDEerrors(llist, ...)
       call add(
 	    \ qfList
 	    \ , { "bufnr": e.bufnr
-	    \   , "filename": e.filename
+	    \   , "filename": printf("%-" . filePadding . "s", e.filename)
+	    \	, "module": empty(e.module) ? e.module : printf("%-" . modulePadding . "s", e.module)
 	    \   , "lnum": e.lnum
 	    \   , "col": e.col
 	    \   , "text": text[0]

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -913,14 +913,10 @@ function! s:PSCIDEpursuitCallback(resp)
   if type(a:resp) != v:t_dict || get(a:resp, "resultType", "error") !=# "success"
     return purescript#ide#handlePursError(a:resp)
   endif
-  if len(a:resp.result) > 1
-    call setloclist(0, map(a:resp.result, { idx, r -> { "text": s:formatpursuit(r) }}))
-    call setloclist(0, [], 'a', {'title': 'Puresuit'})
-    lopen
-    wincmd p
-  else
-    call purescript#ide#utils#log(s:formatpursuit(a:resp.result[0]))
-  endif
+  call setloclist(0, map(a:resp.result, { idx, r -> { "text": s:formatpursuit(r) }}))
+  call setloclist(0, [], 'a', {'title': 'Puresuit'})
+  lopen
+  wincmd p
 endfunction
 
 function! s:formatpursuit(record)

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1323,13 +1323,13 @@ function! s:qfEntry(e, filename, err)
 	\ ? a:e.position.startColumn : 1
   let colend = has_key(a:e, "position") && type(a:e.position) == v:t_dict
   \ ? a:e.position.endColumn : 1
-  return
-	\ { "filename": a:filename
+  return  { "filename": a:filename
+	\ , "module": get(a:e, "moduleName", "")
 	\ , "bufnr": bufnr(a:filename)
 	\ , "lnum": lnum
 	\ , "lnumend": lnumend
 	\ , "col": col
-  \ , "colend": colend
+	\ , "colend": colend
 	\ , "text": a:e.message
 	\ , "type": type
 	\ }

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -433,8 +433,9 @@ function! s:PSCIDEimportIdentifierCallback(resp, ident, view, lines)
   let a:view.lnum = a:view.lnum + line("$") - a:lines
   call winrestview(a:view)
 
-  " trigger PSCIDErebuild through autocmd
-  update
+  " trigger PSCIDErebuild
+  call purescript#ide#utils#update()
+  call PSCIDErebuild(v:true, function("PSCIDEerrors"))
 endfunction
 
 function! PSCIDEgoToDefinition(ident)
@@ -837,8 +838,9 @@ function! PSCIDEapplySuggestionPrime(key, cursor, silent)
     call remove(g:psc_ide_suggestions, a:key)
     let g:psc_ide_suggestions = s:updateSuggestions(startLine, len(newLines) - 1)
 
-    " trigger PSCIDErebuild through autocmd
-    update
+    " trigger PSCIDErebuild
+    call purescript#ide#utils#update()
+    call PSCIDErebuild(v:true, function("PSCIDEerrors"))
   else
     call purescript#ide#utils#debug("multiline suggestions are not supported in vim - please grab g:psc_ide_suggestions and open an issue")
   endif
@@ -1205,8 +1207,9 @@ fun! s:PSCIDEimportModuleCallback(resp)
     call purescript#ide#utils#error(get(a:resp, "result", "error"))
   endif
 
-  " trigger PSCIDErebuild through autocmd
-  update
+  " trigger PSCIDErebuild
+  call purescript#ide#utils#update()
+  call PSCIDErebuild(v:true, function("PSCIDEerrors"))
 endfun
 
 fun! PSCIDEimportModuleCompletion(ArgLead, CmdLine, CursorPos)

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -668,8 +668,8 @@ endfunction
 
 function! s:PSCIDEtypeCallback(ident, result, filterModules)
   if type(a:result) == v:t_list && !empty(a:result)
-      let filePadding = min([max(map(copy(a:result), { i, r -> len(r.definedAt.name)})) + 1, 30])
-      let modulePadding = min([max(map(copy(a:result), { i, r -> len(r.module)})) + 1, 30])
+      let filePadding = min([max(map(copy(a:result), { i, r -> type(r.definedAt) == v:t_dict && has_key(r.definedAt, "name") ? len(r.definedAt.name) : 0})) + 1, 30])
+      let modulePadding = min([max(map(copy(a:result), { i, r -> type(r.module) == v:t_string ? len(r.module) : 0})) + 1, 30])
       call setloclist(0, map(a:result, { idx, r -> s:formattype(r, filePadding, modulePadding)}))
       call setloclist(0, [], 'a', {'title': 'PureScript Types'})
       lopen
@@ -1147,8 +1147,8 @@ fun! s:searchFn(resp)
   endif
   let llist = []
   let result = get(a:resp, "result", [])
-  let filePadding = min([max(map(copy(result), { i, r -> len(r.definedAt.name)})) + 1, 30])
-  let modulePadding = min([max(map(copy(result), { i, r -> len(r.module)})) + 1, 30])
+  let filePadding = min([max(map(copy(result), { i, r -> type(r.definedAt) == v:t_dict && has_key(r.definedAt, "name") ? len(r.definedAt.name) : 0})) + 1, 30])
+  let modulePadding = min([max(map(copy(result), { i, r -> type(r.module) == v:t_string ? len(r.module) : 0})) + 1, 30])
   for res in result
     let llentry = {}
     let bufnr = bufnr(res.definedAt.name)
@@ -1253,8 +1253,8 @@ function! PSCIDEerrors(llist, ...)
     let silent = v:false
   endif
 
-  let filePadding = min([max(map(copy(a:llist), { i, r -> len(r.filename)})) + 1, 30])
-  let modulePadding = min([max(map(copy(a:llist), { i, r -> len(r.module)})) + 1, 30])
+  let filePadding = min([max(map(copy(a:llist), { i, r -> type(r.filename) == v:t_string ? len(r.filename) : 0})) + 1, 30])
+  let modulePadding = min([max(map(copy(a:llist), { i, r -> type(r.module) == v:t_string ? len(r.module) : 0})) + 1, 30])
 
   let qfList = []
   for e in a:llist

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -812,7 +812,17 @@ function! PSCIDEapplySuggestionPrime(key, cursor, silent)
   let endColumn = range.endColumn
   if startLine == endLine
     let line = getline(startLine)
+    " remove trailing news lines
     let replacement = substitute(replacement, '\_s*$', '\n', '')
+    " add identation to each line (except first one)
+    " and remove trailing white space from each line
+    let RSpace = { line -> substitute(line, '\s*$', '', '') }
+    let replacement = join(
+	  \ map(
+	    \ split(replacement, "\n"),
+	    \ { idx, line -> idx == 0 ? RSpace(line) : repeat(" ", startColumn) . RSpace(line)}
+	  \ ),
+	  \ "\n")
     let cursor = getcurpos()
     if startColumn == 1
       let newLines = split(replacement . line[endColumn - 1:], "\n")
@@ -830,7 +840,7 @@ function! PSCIDEapplySuggestionPrime(key, cursor, silent)
     " trigger PSCIDErebuild through autocmd
     update
   else
-    echom "PSCIDEapplySuggestion: multiline suggestions are not yet supported"
+    call purescript#ide#utils#debug("multiline suggestions are not supported in vim - please grab g:psc_ide_suggestions and open an issue")
   endif
 endfunction
 

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -1150,14 +1150,17 @@ fun! s:searchFn(resp)
     return purescript#ide#utils#error(get(a:resp, "result", "error"))
   endif
   let llist = []
-  for res in get(a:resp, "result", [])
+  let result = get(a:resp, "result", [])
+  let filePadding = min([max(map(copy(result), { i, r -> len(r.definedAt.name)})) + 1, 30])
+  let modulePadding = min([max(map(copy(result), { i, r -> len(r.module)})) + 1, 30])
+  for res in result
     let llentry = {}
     let bufnr = bufnr(res.definedAt.name)
     if bufnr != -1
       let llentry.bufnr = bufnr
     endif
-    let llentry.filename = res.definedAt.name
-    let llentry.module = res.module
+    let llentry.filename = printf("%-" . filePadding . "s", res.definedAt.name)
+    let llentry.module = printf("%-" . modulePadding . "s", res.module)
     let llentry.lnum = res.definedAt.start[0]
     let llentry.col = res.definedAt.start[1]
     let llentry.text = printf("%s %s", res.identifier, res.type)


### PR DESCRIPTION
* trigger PSCIDErebuild without autocommands - it's just more reliable
* consistently use location list for PSCIDEtype, PSCIDEsearch, etc (previously when there was a single result it was just echoed)
* check for module support in quickfix/location lists (I am working on a [patch for vim]( https://github.com/vim/vim/pull/1757) that would enable them, now it works with `setqflist` and `setloclist`, what we use in psc-ide-vim, but for vim we need more...). This makes long file names in quicfix / location list short and easy to read.
* PSCIDErebuild - add bang, to reset & reload before compilation