### PR TITLE
Fixed typo causing undefined variable errors

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -621,7 +621,7 @@ function! s:ListImports(module, ...)
   if a:0 >= 1
     let qualifier = a:1
   else
-    let quaifier = ""
+    let qualifier = ""
   endif
 
   call purescript#ide#utils#update()


### PR DESCRIPTION
This was causing me to get.
```
Error detected while processing function PSCIDEtype[1]..<SNR>110_getType[3]..<SNR>110_ListImports:
line 25:
E121: Undefined variable: qualifier
E116: Invalid arguments for function empty(qualifier)
E15: Invalid expression: !empty(qualifier)
```