### PR TITLE
Switch order of fnamemodify modifiers

### DIFF
--- a/autoload/purescript/ide/utils.vim
+++ b/autoload/purescript/ide/utils.vim
@@ -2,11 +2,11 @@
 function! purescript#ide#utils#findRoot()
   let pscPackage = findfile("psc-package.json", fnameescape(expand("%:p:h")).";")
   if !empty(pscPackage)
-    return fnamemodify(pscPackage, ":h:p")
+    return fnamemodify(pscPackage, ":p:h")
   else
     let bower = findfile("bower.json", fnameescape(expand("%:p:h")).";")
     if !empty(bower)
-      return fnamemodify(bower, ":h:p")
+      return fnamemodify(bower, ":p:h")
     else
       return ""
     endif


### PR DESCRIPTION
This actually makes a difference for me. In the old version, `findRoot` would sometimes return a relative path, causing e.g. `Pload` to fail like so:

```
s:callFn: response: ["Couldn't connect to purs ide server on port PortNumber 4242:","Network.Socket.connect: <socket: 27>: does not exist (Connection refused)
",""]
purescript#ide#call: command: {"command":"load"}
purescript#ide#call: no server found
s:startFn: resp: {"resultType":"failed","error":["Couldn't connect to purs ide server on port PortNumber 4242:","Network.Socket.connect: <socket: 27>: does no
t exist (Connection refused)",""]}
s:startFn: starting new server
PSCIDEstart: ["purs","ide","server","-p",4242,"-d","frontend","src/**/*.purs","bower_components/**/*.purs"]
purs ide server: purs: frontend: changeWorkingDirectory: does not exist (No such file or directory)
purs ide server: exit
s:startFn: resending
s:retryFn: response: ["Couldn't connect to purs ide server on port PortNumber 4242:","Network.Socket.connect: <socket: 28>: does not exist (Connection refused
)",""]
purs ide server: Couldn't connect to purs ide server on port PortNumber 4242: Network.Socket.connect: <socket: 28>: does not exist (Connection refused)
```

Note that the `-d` flag is given a relative path. With the fix, I get an absolute path and all is well.

`:help filename-modifiers` says that "These modifiers can be given, in this order:", and `:p` is listed first.

