### PR TITLE
fix #96: completion for non imported qualified identifiers

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -992,8 +992,7 @@ fun! s:omniCommand(ident, qualifier)
     if len(imports)
       call add(filters, purescript#ide#utils#modulesFilter(imports))
     else
-      call purescript#ide#utils#log("None of imported modules is qualified with: \"" . a:qualifier . "\"")
-      return v:null
+      " none of imported modules is qualified with a:qualifier
     endif
     let matcher = s:flexMatcher(a:ident)
   else


### PR DESCRIPTION
* run the completion with qualification
* import the chosen module with the supplied qualification
* remove `canIgnoreModuleParam` of `purescript#ide#imports#identifier`
  since it is not neaded