### PR TITLE
Allow starting `purs ide server` in alternative path

### DIFF
--- a/autoload/purescript/ide.vim
+++ b/autoload/purescript/ide.vim
@@ -2,6 +2,7 @@ let s:started = v:false
 let s:external = v:false
 let s:valid = v:false
 
+
 fun! purescript#ide#started()
   return s:started
 endfun
@@ -42,7 +43,7 @@ fun! purescript#ide#call(input, errorm, isRetry, cb, ...)
     let cwdcommand = {'command': 'cwd'}
 
     let jobid = purescript#job#start(
-	  \ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
+	  \ b:psc_ide_server_runner + ["ide", "client", "-p", b:psc_ide_server_port],
 	  \ { "on_stdout": {ch, msg -> s:startFn(a:input, a:errorm, a:cb, cwdcommand, msg, silent)}
 	  \ , "on_stderr": {ch, err -> purescript#ide#utils#debug("purescript#ide#call error: " . string(err), 3)}
 	  \ })
@@ -52,7 +53,7 @@ fun! purescript#ide#call(input, errorm, isRetry, cb, ...)
 
   let enc = json_encode(a:input)
   let jobid = purescript#job#start(
-	\ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
+	\ b:psc_ide_server_runner + ["ide", "client", "-p", b:psc_ide_server_port],
 	\ { "on_stdout": {ch, msg -> a:cb(s:callFn(a:input, a:errorm, a:isRetry, a:cb, msg))}
 	\ , "on_stderr": {ch, err -> purescript#ide#utils#debug("purescript#ide#call error: " . purescript#ide#utils#toString(err), 0)}
 	\ })
@@ -72,14 +73,14 @@ fun! purescript#ide#callSync(input, errorm, isRetry)
     let cwdcommand = {'command': 'cwd'}
 
     call purescript#ide#utils#debug("purescript#ide#callSync: no server found", 1)
-    let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
-    let cwdresp = system(join(cmd) . g:psc_ide_server_port, json_encode(cwdcommand))
+    let cmd = b:psc_ide_server_runner + ["ide", "client", "-p"]
+    let cwdresp = system(join(cmd) . b:psc_ide_server_port, json_encode(cwdcommand))
     return s:startFn(a:input, a:errorm, 0, cwdcommand, cwdresp)
   else
     call purescript#ide#utils#debug("purescript#ide#callSync: trying to reach server again", 1)
     let enc = json_encode(a:input)
-    let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
-    let resp = system(join(cmd) . g:psc_ide_server_port, enc)
+    let cmd = b:psc_ide_server_runner + ["ide", "client", "-p"]
+    let resp = system(join(cmd) . b:psc_ide_server_port, enc)
     return s:callFn(a:input, a:errorm, a:isRetry, 0, resp)
   endif
 endfun
@@ -114,15 +115,15 @@ fun! s:startFn(input, errorm, cb, cwdcommand, cwdresp, ...)
   endif
   call purescript#ide#utils#debug("s:startFn: resending", 1)
   if (type(a:cb) == type(0) && !a:cb)
-    let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
+    let cmd = b:psc_ide_server_runner + ["ide", "client", "-p"]
     let cwdresp = system(
-	  \ join(cmd) . g:psc_ide_server_port,
+	  \ join(cmd) . b:psc_ide_server_port,
 	  \ json_encode(a:cwdcommand)
 	  \ )
     call s:retryFn(a:input, a:errorm, 0, cwd, cwdresp)
   else
     let jobid = purescript#job#start(
-	  \ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
+	  \ b:psc_ide_server_runner + ["ide", "client", "-p", b:psc_ide_server_port],
 	  \ { "on_stdout": { ch, resp -> s:retryFn(a:input, a:errorm, a:cb, cwd, resp, silent) }
 	  \ , "on_stderr": { ch, err -> silent ? purescript#ide#utils#warn(purescript#ide#utils#toString(err)) : v:null }
 	  \ }
@@ -162,10 +163,10 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
   endif
 
   let enc = json_encode(a:input)
-  let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
+  let cmd = b:psc_ide_server_runner + ["ide", "client", "-p"]
   if (type(a:cb) == type(0))
     let resp = system(
-	  \ join(cmd) . g:psc_ide_server_port,
+	  \ join(cmd) . b:psc_ide_server_port,
 	  \ enc
 	  \ )
     return s:callFn(a:input, a:errorm, 1, 0, resp)
@@ -173,14 +174,14 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
 
   if (type(a:cb) == type(0) && !a:cb)
     let resp = system(
-	  \ join(cmd) . g:psc_ide_server_port
+	  \ join(cmd) . b:psc_ide_server_port
 	  \ enc
 	  \ )
     return s:callFn(a:input, a:errorm, 1, 0, resp)
   endif
   call purescript#ide#utils#debug("callPscIde: command: " . enc, 3)
   let jobid = purescript#job#start(
-	\ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
+	\ b:psc_ide_server_runner + ["ide", "client", "-p", b:psc_ide_server_port],
 	\ { "on_stdout": {ch, resp -> a:cb(s:callFn(a:input, a:errorm, 1, a:cb, resp, silent))}
 	\ , "on_stderr": {ch, err -> purescript#ide#utils#debug("s:retryFn error: " . err, 3)}
 	\ })

--- a/autoload/purescript/ide.vim
+++ b/autoload/purescript/ide.vim
@@ -42,7 +42,7 @@ fun! purescript#ide#call(input, errorm, isRetry, cb, ...)
     let cwdcommand = {'command': 'cwd'}
 
     let jobid = purescript#job#start(
-	  \ ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	  \ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
 	  \ { "on_stdout": {ch, msg -> s:startFn(a:input, a:errorm, a:cb, cwdcommand, msg, silent)}
 	  \ , "on_stderr": {ch, err -> purescript#ide#utils#debug("purescript#ide#call error: " . string(err), 3)}
 	  \ })
@@ -52,7 +52,7 @@ fun! purescript#ide#call(input, errorm, isRetry, cb, ...)
 
   let enc = json_encode(a:input)
   let jobid = purescript#job#start(
-	\ ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	\ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
 	\ { "on_stdout": {ch, msg -> a:cb(s:callFn(a:input, a:errorm, a:isRetry, a:cb, msg))}
 	\ , "on_stderr": {ch, err -> purescript#ide#utils#debug("purescript#ide#call error: " . purescript#ide#utils#toString(err), 0)}
 	\ })
@@ -72,12 +72,14 @@ fun! purescript#ide#callSync(input, errorm, isRetry)
     let cwdcommand = {'command': 'cwd'}
 
     call purescript#ide#utils#debug("purescript#ide#callSync: no server found", 1)
-    let cwdresp = system("purs ide client -p " . g:psc_ide_server_port, json_encode(cwdcommand))
+    let cmd = g:psc_ide_server_runner + ["purs", "ide", "client", "-p"]
+    let cwdresp = system(join(cmd) . g:psc_ide_server_port, json_encode(cwdcommand))
     return s:startFn(a:input, a:errorm, 0, cwdcommand, cwdresp)
   else
     call purescript#ide#utils#debug("purescript#ide#callSync: trying to reach server again", 1)
     let enc = json_encode(a:input)
-    let resp = system("purs ide client -p " . g:psc_ide_server_port, enc)
+    let cmd = g:psc_ide_server_runner + ["purs", "ide", "client", "-p"]
+    let resp = system(join(cmd) . g:psc_ide_server_port, enc)
     return s:callFn(a:input, a:errorm, a:isRetry, 0, resp)
   endif
 endfun
@@ -112,14 +114,15 @@ fun! s:startFn(input, errorm, cb, cwdcommand, cwdresp, ...)
   endif
   call purescript#ide#utils#debug("s:startFn: resending", 1)
   if (type(a:cb) == type(0) && !a:cb)
+    let cmd = g:psc_ide_server_runner + ["purs", "ide", "client", "-p"]
     let cwdresp = system(
-	  \ "purs ide client -p" . g:psc_ide_server_port,
+	  \ join(cmd) . g:psc_ide_server_port,
 	  \ json_encode(a:cwdcommand)
 	  \ )
     call s:retryFn(a:input, a:errorm, 0, cwd, cwdresp)
   else
     let jobid = purescript#job#start(
-	  \ ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	  \ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
 	  \ { "on_stdout": { ch, resp -> s:retryFn(a:input, a:errorm, a:cb, cwd, resp, silent) }
 	  \ , "on_stderr": { ch, err -> silent ? purescript#ide#utils#warn(purescript#ide#utils#toString(err)) : v:null }
 	  \ }
@@ -144,7 +147,7 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
     let cwdresp2Decoded = {"resultType": "failed", "error": a:cwdresp2}
   endtry
 
-  if type(cwdresp2Decoded) == v:t_dict && cwdresp2Decoded.resultType ==# 'success' 
+  if type(cwdresp2Decoded) == v:t_dict && cwdresp2Decoded.resultType ==# 'success'
      \ && cwdresp2Decoded.result == a:expectedCWD
     call purescript#ide#utils#debug("s:retryFn: success", 1)
     call PSCIDEload(1, "")
@@ -159,9 +162,10 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
   endif
 
   let enc = json_encode(a:input)
+  let cmd = g:psc_ide_server_runner + ["pusr", "ide", "client", "-p"]
   if (type(a:cb) == type(0))
     let resp = system(
-	  \ "purs ide client -p" . g:psc_ide_server_port,
+	  \ join(cmd) . g:psc_ide_server_port,
 	  \ enc
 	  \ )
     return s:callFn(a:input, a:errorm, 1, 0, resp)
@@ -169,14 +173,14 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
 
   if (type(a:cb) == type(0) && !a:cb)
     let resp = system(
-	  \ "purs ide client -p" . g:psc_ide_server_port
+	  \ join(cmd) . g:psc_ide_server_port
 	  \ enc
 	  \ )
     return s:callFn(a:input, a:errorm, 1, 0, resp)
   endif
   call purescript#ide#utils#debug("callPscIde: command: " . enc, 3)
   let jobid = purescript#job#start(
-	\ ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	\ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
 	\ { "on_stdout": {ch, resp -> a:cb(s:callFn(a:input, a:errorm, 1, a:cb, resp, silent))}
 	\ , "on_stderr": {ch, err -> purescript#ide#utils#debug("s:retryFn error: " . err, 3)}
 	\ })
@@ -215,7 +219,7 @@ fun! s:callFn(input, errorm, isRetry, cb, resp, ...)
     endif
   endtry
 
-  if (type(decoded) != type({}) || decoded['resultType'] !=# 'success') 
+  if (type(decoded) != type({}) || decoded['resultType'] !=# 'success')
       \ && type(a:errorm) == v:t_string
     call purescript#ide#utils#log(a:errorm)
   endif

--- a/autoload/purescript/ide.vim
+++ b/autoload/purescript/ide.vim
@@ -42,7 +42,7 @@ fun! purescript#ide#call(input, errorm, isRetry, cb, ...)
     let cwdcommand = {'command': 'cwd'}
 
     let jobid = purescript#job#start(
-	  \ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	  \ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
 	  \ { "on_stdout": {ch, msg -> s:startFn(a:input, a:errorm, a:cb, cwdcommand, msg, silent)}
 	  \ , "on_stderr": {ch, err -> purescript#ide#utils#debug("purescript#ide#call error: " . string(err), 3)}
 	  \ })
@@ -52,7 +52,7 @@ fun! purescript#ide#call(input, errorm, isRetry, cb, ...)
 
   let enc = json_encode(a:input)
   let jobid = purescript#job#start(
-	\ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	\ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
 	\ { "on_stdout": {ch, msg -> a:cb(s:callFn(a:input, a:errorm, a:isRetry, a:cb, msg))}
 	\ , "on_stderr": {ch, err -> purescript#ide#utils#debug("purescript#ide#call error: " . purescript#ide#utils#toString(err), 0)}
 	\ })
@@ -72,13 +72,13 @@ fun! purescript#ide#callSync(input, errorm, isRetry)
     let cwdcommand = {'command': 'cwd'}
 
     call purescript#ide#utils#debug("purescript#ide#callSync: no server found", 1)
-    let cmd = g:psc_ide_server_runner + ["purs", "ide", "client", "-p"]
+    let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
     let cwdresp = system(join(cmd) . g:psc_ide_server_port, json_encode(cwdcommand))
     return s:startFn(a:input, a:errorm, 0, cwdcommand, cwdresp)
   else
     call purescript#ide#utils#debug("purescript#ide#callSync: trying to reach server again", 1)
     let enc = json_encode(a:input)
-    let cmd = g:psc_ide_server_runner + ["purs", "ide", "client", "-p"]
+    let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
     let resp = system(join(cmd) . g:psc_ide_server_port, enc)
     return s:callFn(a:input, a:errorm, a:isRetry, 0, resp)
   endif
@@ -114,7 +114,7 @@ fun! s:startFn(input, errorm, cb, cwdcommand, cwdresp, ...)
   endif
   call purescript#ide#utils#debug("s:startFn: resending", 1)
   if (type(a:cb) == type(0) && !a:cb)
-    let cmd = g:psc_ide_server_runner + ["purs", "ide", "client", "-p"]
+    let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
     let cwdresp = system(
 	  \ join(cmd) . g:psc_ide_server_port,
 	  \ json_encode(a:cwdcommand)
@@ -122,7 +122,7 @@ fun! s:startFn(input, errorm, cb, cwdcommand, cwdresp, ...)
     call s:retryFn(a:input, a:errorm, 0, cwd, cwdresp)
   else
     let jobid = purescript#job#start(
-	  \ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	  \ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
 	  \ { "on_stdout": { ch, resp -> s:retryFn(a:input, a:errorm, a:cb, cwd, resp, silent) }
 	  \ , "on_stderr": { ch, err -> silent ? purescript#ide#utils#warn(purescript#ide#utils#toString(err)) : v:null }
 	  \ }
@@ -162,7 +162,7 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
   endif
 
   let enc = json_encode(a:input)
-  let cmd = g:psc_ide_server_runner + ["pusr", "ide", "client", "-p"]
+  let cmd = g:psc_ide_server_runner + ["ide", "client", "-p"]
   if (type(a:cb) == type(0))
     let resp = system(
 	  \ join(cmd) . g:psc_ide_server_port,
@@ -180,7 +180,7 @@ fun! s:retryFn(input, errorm, cb, expectedCWD, cwdresp2, ...)
   endif
   call purescript#ide#utils#debug("callPscIde: command: " . enc, 3)
   let jobid = purescript#job#start(
-	\ g:psc_ide_server_runner + ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	\ g:psc_ide_server_runner + ["ide", "client", "-p", g:psc_ide_server_port],
 	\ { "on_stdout": {ch, resp -> a:cb(s:callFn(a:input, a:errorm, 1, a:cb, resp, silent))}
 	\ , "on_stderr": {ch, err -> purescript#ide#utils#debug("s:retryFn error: " . err, 3)}
 	\ })

--- a/doc/psc-ide-vim.txt
+++ b/doc/psc-ide-vim.txt
@@ -174,7 +174,7 @@ Default is false
 >
 
 g:psc_ide_omnicompletion_sort_by [ident]
-<Determins the sort order of the 'omnicomplete' results. Must be one of the following:
+<Determines the sort order of the 'omnicomplete' results. Must be one of the following:
   flex          default sort
   module        compares on module name
   identifier    compares on the identifier name
@@ -191,8 +191,8 @@ g:psc_ide_omnicompletion_prefix_filter [ident]
 >
 
 g:psc_ide_server_runner [ident]
-<Allows using project-local or sandboxed versions of 'purs ide server' by appending a prefix. For
-example, 'yarn --silent' if using a project-dependent version + yarn. Default is []
+<Allows using project-local or sandboxed versions of 'purs ide server' by supplying an alternative command for 'purs'. For
+example, 'yarn --silent purs' if using a project-dependent version + yarn. Default is ["purs"]
 >
 
 g:psc_ide_filter_submodules [ident]

--- a/doc/psc-ide-vim.txt
+++ b/doc/psc-ide-vim.txt
@@ -3,7 +3,7 @@ PureScript psc ide integration			      *psc-ide-vim* *purs*
 COMPLETION					      *purs-completion*
 The plugin provides omni completion |i_CTRL-X_CTRL-O| for your PureScript
 coding and user completion so you can complete with |i_CTRL-X_CTRL-U| too.
-The 'omnifunc' is though to provide as thigh list of results as possible,
+The 'omnifunc' is though to provide as tight list of results as possible,
 while the user completion is though to find as many results as possible.
 
 Both completion function will work with qualified and unqualified
@@ -138,3 +138,68 @@ taken.
  :Psearch ident
 <Search for identifier.  This works like the provided 'omnifunc', but with
 less filtering.
+<
+
+SETTINGS                                *purs-settings*
+
+>
+ g:psc_ide_log_level [ident]
+<Controls the verbosity of debug output.
+  0 =       no output
+  1 =       less output
+  2 =       more output
+  3 =       debug outupt
+
+  default is 0
+>
+ g:psc_ide_server_port [ident]
+<Use an alternative port for 'purs ide server'. The default is 4242
+>
+ g:psc_ide_check_output_dir [ident]
+<Used for project validation, this checks whether the project has been built yet. The
+default is 1 (True)
+>
+
+ g:psc_ide_notify [ident]
+<Prints additional logging information about calls to 'purs ide server'. Default is true
+>
+
+g:psc_ide_filter_prelude_modules [ident]
+<Filters out
+>
+
+g:psc_ide_omnicompletion_filter_modules [ident]
+<Performs the 'omnicomplete' search only against the currently imported set of modules.
+Default is false
+>
+
+g:psc_ide_omnicompletion_sort_by [ident]
+<Determins the sort order of the 'omnicomplete' results. Must be one of the following:
+  flex          default sort
+  module        compares on module name
+  identifier    compares on the identifier name
+
+  default is flex
+>
+
+g:psc_ide_import_on_completion [ident]
+<Import identifiers on completion callback. Default is true
+>
+
+g:psc_ide_omnicompletion_prefix_filter [ident]
+<Allows purs ide to filter by prefix, disabling flex matching. Default is true.
+>
+
+g:psc_ide_server_runner [ident]
+<Allows using project-local or sandboxed versions of 'purs ide server' by appending a prefix. For
+example, 'yarn --silent' if using a project-dependent version + yarn. Default is []
+>
+
+g:psc_ide_filter_submodules [ident]
+<Hides submodules. Default is false
+>
+
+g:psc_ide_filter_submodules_do_not_hide [ident]
+<A list of submodules that should not be hidden by 'g:psc_ide_filter_submodules'
+>
+

--- a/doc/psc-ide-vim.txt
+++ b/doc/psc-ide-vim.txt
@@ -152,7 +152,7 @@ SETTINGS                                *purs-settings*
 
   default is 0
 >
- g:psc_ide_server_port [ident]
+ g:psc_ide_server_port ident
 <Use an alternative port for 'purs ide server'. The default is 4242
 >
  g:psc_ide_check_output_dir [ident]
@@ -192,7 +192,7 @@ g:psc_ide_omnicompletion_prefix_filter [ident]
 
 g:psc_ide_server_runner [ident]
 <Allows using project-local or sandboxed versions of 'purs ide server' by supplying an alternative command for 'purs'. For
-example, 'yarn --silent purs' if using a project-dependent version + yarn. Default is ["purs"]
+example, ["yarn", "--silent", "purs"] if using a project-dependent version + yarn. Default is ["purs"]
 >
 
 g:psc_ide_filter_submodules [ident]

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -18,10 +18,6 @@ if !exists('g:psc_ide_log_level')
   let g:psc_ide_log_level = 0
 endif
 
-if !exists('g:psc_ide_auto_imports')
-  let g:psc_ide_auto_imports = 0
-endif
-
 if !exists('g:psc_ide_server_port')
   let g:psc_ide_server_port = 4242
 endif

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -54,7 +54,7 @@ if !exists("g:psc_ide_omnicompletion_prefix_filter")
 endif
 
 if !exists("g:psc_ide_server_runner")
-    let g:psc_ide_server_runner = []
+    let g:psc_ide_server_runner = ["purs"]
 endif
 
 if !exists("g:psc_ide_prelude")
@@ -221,7 +221,7 @@ function! PSCIDEstart(silent)
   endif
 
   let command = g:psc_ide_server_runner+ [
-	\ "purs", "ide", "server",
+	\ "ide", "server",
 	\ "-p", g:psc_ide_server_port,
 	\ "-d", dir,
 	\ "src/**/*.purs",
@@ -273,7 +273,7 @@ function! PSCIDEend()
   let runnerCmd = g:psc_ide_server_runner
   let jobid = purescript#job#start(
     \ runnerCmd +
-	\ ["purs", "ide", "client", "-p", g:psc_ide_server_port],
+	\ ["ide", "client", "-p", g:psc_ide_server_port],
 	\ { "on_exit": {job, status, ev -> s:PSCIDEendCallback() }
 	\ , "on_stderr": {err -> purescript#ide#utils#log(string(err), v:true)}
 	\ })

--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -57,6 +57,9 @@ if !exists("g:psc_ide_server_runner")
     let g:psc_ide_server_runner = ["purs"]
 endif
 
+let b:psc_ide_server_runner = g:psc_ide_server_runner
+let b:psc_ide_server_port = g:psc_ide_server_port
+
 if !exists("g:psc_ide_prelude")
   let g:psc_ide_prelude = [
     \ "Control.Applicative",
@@ -220,9 +223,9 @@ function! PSCIDEstart(silent)
     return
   endif
 
-  let command = g:psc_ide_server_runner+ [
+  let command = b:psc_ide_server_runner+ [
 	\ "ide", "server",
-	\ "-p", g:psc_ide_server_port,
+	\ "-p", b:psc_ide_server_port,
 	\ "-d", dir,
 	\ "src/**/*.purs",
 	\ "bower_components/**/*.purs",
@@ -270,10 +273,10 @@ function! PSCIDEend()
     return
   endif
 
-  let runnerCmd = g:psc_ide_server_runner
+  let runnerCmd = b:psc_ide_server_runner
   let jobid = purescript#job#start(
     \ runnerCmd +
-	\ ["ide", "client", "-p", g:psc_ide_server_port],
+	\ ["ide", "client", "-p", b:psc_ide_server_port],
 	\ { "on_exit": {job, status, ev -> s:PSCIDEendCallback() }
 	\ , "on_stderr": {err -> purescript#ide#utils#log(string(err), v:true)}
 	\ })


### PR DESCRIPTION
On many of the purescript projects I work on we have the purs version pinned in the `package.json`. That often creates compatibility issues between the project versions & my globally installed versions. This change enables prepending an optional "runner" command in front of the `purs ide server` & `purs ide client` commands.  

I also added documentation for the settings (happy to split that out into a separate PR if you prefer. 