### PR TITLE
Add `psc_ide_codegen` option.

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -47,6 +47,11 @@ if !exists('g:psc_ide_omnicompletion_sort_by')
   let g:psc_ide_omnicompletion_sort_by = "flex"
 endif
 
+if !exists('g:psc_ide_codegen')
+  " js / corefn / sourcemaps
+  let g:psc_ide_codegen = ['js']
+endif
+
 if !exists('g:psc_ide_import_on_completion')
   let g:psc_ide_import_on_completion = v:true
 endif
@@ -453,7 +458,7 @@ endfunction
 function! PSCIDErebuild(async, bang, ...)
 
   let filename = expand("%:p")
-  let input = {'command': 'rebuild', 'params': {'file': filename}}
+  let input = {'command': 'rebuild', 'params': {'file': filename, 'codegen': g:psc_ide_codegen}}
 
   if a:0 >= 1 && type(a:1) == v:t_func
     let CallBack = a:1


### PR DESCRIPTION
@kRITZCREEK has just added and [confirmed](https://github.com/purescript/purescript/pull/3449#issuecomment-435176974) that we are going to have `codegen` field added to `Rebuild` command in the `0.12.1`.
This option is backward compatible and won't break communication with older versions of `purs ide`.

I've tested this PR against his feature branch and this works fine.

Related commit with protocol changes:
https://github.com/purescript/purescript/pull/3449/commits/28b5f4de122caf6bdc7b493814f1bd81e7198c86#diff-ac462992255ed7355c644aba72041011R26