### PR TITLE
Add option "--editor-mode" on project startup

### DIFF
--- a/ftplugin/purescript_pscide.vim
+++ b/ftplugin/purescript_pscide.vim
@@ -223,6 +223,7 @@ function! PSCIDEstart(silent)
 	\ "purs", "ide", "server",
 	\ "-p", g:psc_ide_server_port,
 	\ "-d", dir,
+	\ "--editor-mode",
 	\ "src/**/*.purs",
 	\ "bower_components/**/*.purs",
 	\ ]


### PR DESCRIPTION
Reference: 
https://github.com/purescript/purescript/issues/2249

This fixes the reported issue in psc-ide with very high CPU consumption even when idle on my end.